### PR TITLE
Add extra sentry information only if sentry enabled

### DIFF
--- a/sipa/blueprints/generic.py
+++ b/sipa/blueprints/generic.py
@@ -27,10 +27,11 @@ bp_generic = Blueprint('generic', __name__)
 
 @bp_generic.before_app_request
 def log_request():
-    current_app.extensions['sentry'].client.extra_context({
-        'current_user': current_user,
-        'ip_user': user_from_ip(request.remote_addr)
-    })
+    if 'sentry' in current_app.extensions:
+        current_app.extensions['sentry'].client.extra_context({
+            'current_user': current_user,
+            'ip_user': user_from_ip(request.remote_addr)
+        })
 
     logging.getLogger(__name__ + '.http').debug(
         'Incoming request: %s %s', request.method, request.path,


### PR DESCRIPTION
SIPA does not run without sentry. Making any requests results in exception.
```
Traceback (most recent call last):
  File "/home/shreyder/.virtualenvs/sipa/lib/python3.5/site-packages/flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/shreyder/.virtualenvs/sipa/lib/python3.5/site-packages/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/shreyder/.virtualenvs/sipa/lib/python3.5/site-packages/flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/home/shreyder/.virtualenvs/sipa/lib/python3.5/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/home/shreyder/.virtualenvs/sipa/lib/python3.5/site-packages/flask/app.py", line 1473, in full_dispatch_request
    rv = self.preprocess_request()
  File "/home/shreyder/.virtualenvs/sipa/lib/python3.5/site-packages/flask/app.py", line 1666, in preprocess_request
    rv = func()
  File "/home/shreyder/agdsn/sipa/sipa/blueprints/generic.py", line 30, in log_request
    current_app.extensions['sentry'].client.extra_context({
KeyError: 'sentry'

```