### PR TITLE
Replace wrong use of gettext with lazy_gettext

### DIFF
--- a/model/constants.py
+++ b/model/constants.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 
-from flask.ext.babel import gettext
+from flask.ext.babel import lazy_gettext
 
 
 WEEKDAYS = (
-    gettext('Montag'),
-    gettext('Dienstag'),
-    gettext('Mittwoch'),
-    gettext('Donnerstag'),
-    gettext('Freitag'),
-    gettext('Samstag'),
-    gettext('Sonntag'),
+    lazy_gettext('Montag'),
+    lazy_gettext('Dienstag'),
+    lazy_gettext('Mittwoch'),
+    lazy_gettext('Donnerstag'),
+    lazy_gettext('Freitag'),
+    lazy_gettext('Samstag'),
+    lazy_gettext('Sonntag'),
 )

--- a/model/gerok/__init__.py
+++ b/model/gerok/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from flask.ext.babel import gettext
+from flask.ext.babel import lazy_gettext
 from ..datasource import DataSource, Dormitory
 from ipaddress import IPv4Network
 
@@ -16,7 +16,7 @@ def init_context(app):
 
 datasource = DataSource(
     name='gerok',
-    display_name=gettext("Gerokstraße"),
+    display_name=lazy_gettext("Gerokstraße"),
     user_class=user.User,
     mail_server="wh17.tu-dresden.de",
     support_mail="gerok@wh17.tu-dresden.de",

--- a/model/sample/__init__.py
+++ b/model/sample/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from flask.ext.babel import gettext
+from flask.ext.babel import lazy_gettext
 from ..datasource import DataSource, Dormitory
 from ipaddress import IPv4Network
 
@@ -8,7 +8,7 @@ from . import user
 
 datasource = DataSource(
     name='sample',
-    display_name=gettext("Beispielsektion"),
+    display_name=lazy_gettext("Beispielsektion"),
     user_class=user.User,
     mail_server="test.agdsn.de",
     init_context=user.init_context,

--- a/model/wu/__init__.py
+++ b/model/wu/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from flask.ext.babel import gettext
+from flask.ext.babel import lazy_gettext
 from ..datasource import DataSource, Dormitory
 from .database_utils import init_db
 from ipaddress import IPv4Network
@@ -16,7 +16,7 @@ def init_context(app):
 
 datasource = DataSource(
     name='wu',
-    display_name=gettext("Wundtstraße & Zellescher Weg"),
+    display_name=lazy_gettext("Wundtstraße & Zellescher Weg"),
     user_class=user.User,
     mail_server="wh2.tu-dresden.de",
     init_context=init_context

--- a/model/wu/database_utils.py
+++ b/model/wu/database_utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from sqlalchemy import create_engine
-from flask.ext.babel import gettext
+from flask.ext.babel import lazy_gettext
 from flask.globals import current_app
 
 from werkzeug.local import LocalProxy
@@ -49,12 +49,12 @@ DORMITORIES = [
 ]
 
 STATUS = {
-    1: (gettext('Bezahlt, verbunden'), 'success'),
-    2: (gettext('Nicht bezahlt, Netzanschluss gesperrt'), 'warning'),
-    7: (gettext('Verstoß gegen Netzordnung, Netzanschluss gesperrt'),
+    1: (lazy_gettext('Bezahlt, verbunden'), 'success'),
+    2: (lazy_gettext('Nicht bezahlt, Netzanschluss gesperrt'), 'warning'),
+    7: (lazy_gettext('Verstoß gegen Netzordnung, Netzanschluss gesperrt'),
         'danger'),
-    9: (gettext('Exaktiv'), 'muted'),
-    12: (gettext('Trafficlimit überschritten, Netzanschluss gesperrt'),
+    9: (lazy_gettext('Exaktiv'), 'muted'),
+    12: (lazy_gettext('Trafficlimit überschritten, Netzanschluss gesperrt'),
          'danger')
 }
 

--- a/sipa/forms.py
+++ b/sipa/forms.py
@@ -78,7 +78,8 @@ class ReadonlyStringField(StrippedStringField):
 class ContactForm(Form):
     email = ReadonlyStringField(
         label=lazy_gettext("Deine E-Mail-Adresse"),
-        validators=[Email(gettext("E-Mail ist nicht in gültigem Format!"))],
+        validators=[Email(lazy_gettext("E-Mail ist nicht in gültigem "
+                                       "Format!"))],
     )
     type = SelectField(label=lazy_gettext("Kategorie"), choices=[
         ("frage", lazy_gettext("Allgemeine Frage an die Administratoren")),
@@ -88,16 +89,16 @@ class ContactForm(Form):
         ("eigene-technik", lazy_gettext("Probleme mit privater Technik"))
     ])
     subject = StrippedStringField(label=lazy_gettext("Betreff"), validators=[
-        DataRequired(gettext("Betreff muss angegeben werden!"))])
+        DataRequired(lazy_gettext("Betreff muss angegeben werden!"))])
     message = TextAreaField(label=lazy_gettext("Nachricht"), validators=[
-        DataRequired(gettext("Nachricht fehlt!"))
+        DataRequired(lazy_gettext("Nachricht fehlt!"))
     ])
 
 
 class AnonymousContactForm(Form):
     email = StrippedStringField(
         label=lazy_gettext("Deine E-Mail-Adresse"),
-        validators=[Email(gettext("E-Mail ist nicht in gültigem Format!"))],
+        validators=[Email(lazy_gettext("E-Mail ist nicht in gültigem Format!"))],
     )
     dormitory = SelectField(
         label=lazy_gettext("Wohnheim"),
@@ -105,38 +106,38 @@ class AnonymousContactForm(Form):
         default=LocalProxy(lambda: preferred_dormitory_name()),
     )
     subject = StrippedStringField(label=lazy_gettext("Betreff"), validators=[
-        DataRequired(gettext("Betreff muss angegeben werden!"))])
+        DataRequired(lazy_gettext("Betreff muss angegeben werden!"))])
     message = TextAreaField(label=lazy_gettext("Nachricht"), validators=[
-        DataRequired(gettext("Nachricht fehlt!"))
+        DataRequired(lazy_gettext("Nachricht fehlt!"))
     ])
 
 
 class ChangePasswordForm(Form):
     old = PasswordField(label=lazy_gettext("Altes Passwort"), validators=[
-        DataRequired(gettext("Altes Passwort muss angegeben werden!"))])
+        DataRequired(lazy_gettext("Altes Passwort muss angegeben werden!"))])
     new = PasswordField(label=lazy_gettext("Neues Passwort"), validators=[
-        DataRequired(gettext("Neues Passwort fehlt!")),
+        DataRequired(lazy_gettext("Neues Passwort fehlt!")),
         PasswordComplexity(),
     ])
     confirm = PasswordField(label=lazy_gettext("Bestätigung"), validators=[
-        DataRequired(gettext("Bestätigung des neuen Passworts fehlt!")),
+        DataRequired(lazy_gettext("Bestätigung des neuen Passworts fehlt!")),
         EqualTo('new',
-                message=gettext("Neue Passwörter stimmen nicht überein!"))
+                message=lazy_gettext("Neue Passwörter stimmen nicht überein!"))
     ])
 
 
 class ChangeMailForm(Form):
     password = PasswordField(
         label=lazy_gettext("Passwort"),
-        validators=[DataRequired(gettext("Passwort nicht angegeben!"))])
+        validators=[DataRequired(lazy_gettext("Passwort nicht angegeben!"))])
     email = StrippedStringField(
         label=lazy_gettext("Neue Mail"),
-        validators=[Email(gettext("E-Mail ist nicht in gültigem Format!"))])
+        validators=[Email(lazy_gettext("E-Mail ist nicht in gültigem Format!"))])
 
 
 class DeleteMailForm(Form):
     password = PasswordField(
-        validators=[DataRequired(gettext("Passwort nicht angegeben!"))])
+        validators=[DataRequired(lazy_gettext("Passwort nicht angegeben!"))])
 
 
 def require_unicast_mac(form, field):
@@ -152,7 +153,7 @@ def require_unicast_mac(form, field):
 class ChangeMACForm(Form):
     password = PasswordField(
         label=lazy_gettext("Passwort"),
-        validators=[DataRequired(gettext("Passwort nicht angegeben!"))])
+        validators=[DataRequired(lazy_gettext("Passwort nicht angegeben!"))])
     mac = StrippedStringField(
         label=lazy_gettext("Neue MAC"),
         validators=[DataRequired("MAC-Adresse nicht angegeben!"),
@@ -166,32 +167,32 @@ class LoginForm(Form):
         choices=LocalProxy(list_all_dormitories),
         default=LocalProxy(lambda: preferred_dormitory_name()),
         validators=[AnyOf([dorm.name for dorm in registered_dormitories],
-                          message=gettext("Kein gültiges Wohnheim!"))]
+                          message=lazy_gettext("Kein gültiges Wohnheim!"))]
     )
     username = StrippedStringField(
         label=lazy_gettext("Nutzername"),
         validators=[
-            DataRequired(gettext("Nutzername muss angegeben werden!")),
-            Regexp("^[^,+\"\\<>;#]+$", message=gettext(
+            DataRequired(lazy_gettext("Nutzername muss angegeben werden!")),
+            Regexp("^[^,+\"\\<>;#]+$", message=lazy_gettext(
                 "Nutzername enthält ungültige Zeichen!")),
         ],
     )
     password = PasswordField(
         label=lazy_gettext("Passwort"),
-        validators=[DataRequired(gettext("Kein Passwort eingegeben!"))]
+        validators=[DataRequired(lazy_gettext("Kein Passwort eingegeben!"))]
     )
     remember = BooleanField(default=lazy_gettext("Anmeldung merken"))
 
 
 class HostingForm(Form):
     password = PasswordField(lazy_gettext("Passwort"), validators=[
-        DataRequired(gettext("Kein Passwort eingegeben!")),
+        DataRequired(lazy_gettext("Kein Passwort eingegeben!")),
         PasswordComplexity(),
     ])
     confirm = PasswordField(lazy_gettext("Bestätigung"), validators=[
-        DataRequired(gettext("Bestätigung des neuen Passworts fehlt!")),
+        DataRequired(lazy_gettext("Bestätigung des neuen Passworts fehlt!")),
         EqualTo('password',
-                message=gettext("Neue Passwörter stimmen nicht überein!"))
+                message=lazy_gettext("Neue Passwörter stimmen nicht überein!"))
     ])
     action = HiddenField()
 


### PR DESCRIPTION
In places that are executed during application initialization (as opposed to
request processing) lazy_gettext must be used, as the locale of the user is not
known yet.