### PR TITLE
Hss ldap

### DIFF
--- a/build/requirements/requirements_testing.txt
+++ b/build/requirements/requirements_testing.txt
@@ -3,3 +3,4 @@ Flask-Testing==0.4.2
 nose==1.3.7
 rednose==0.4.3
 psycopg2==2.6.1
+profilehooks==1.8.1

--- a/build/testing.yml
+++ b/build/testing.yml
@@ -7,7 +7,9 @@ services:
       args:
         additional_requirements: requirements_testing.txt
     image: sipa_testing
-    command: python manage.py test
+    # Run `test` (doing nothing) because the tests should be triggered manually
+    # Running them on startup won't work because the LDAP won't be ready yet
+    command: test
     volumes:
       # Note: ../ is relative to the path of the .yml
       # Thus: be careful with symlinks!

--- a/sipa/model/hss/ldap.py
+++ b/sipa/model/hss/ldap.py
@@ -85,6 +85,11 @@ class BaseLdapConnector(ldap3.Connection, metaclass=ABCMeta):
 
     @classmethod
     def fetch_user(cls, username):
+        """Fetch `username` from LDAP, return a dict.
+
+        :param: username the username to be used in cls.__init__()
+        :returns: a dict {'uid': '', 'name': ''} containing the user data
+        """
         with cls.system_bind() as connection:
             connection.search(
                 search_base=cls.config['search_base'],

--- a/sipa/model/hss/ldap.py
+++ b/sipa/model/hss/ldap.py
@@ -102,7 +102,6 @@ class BaseLdapConnector(ldap3.Connection, metaclass=ABCMeta):
             )
 
         if connection is not None:
-            print("connection:", connection)
             _search(connection)
             response = connection.response
         else:

--- a/sipa/model/hss/ldap.py
+++ b/sipa/model/hss/ldap.py
@@ -53,6 +53,7 @@ class BaseLdapConnector(ldap3.Connection, metaclass=ABCMeta):
         self.server = ldap3.Server(
             host=self.config['host'],
             port=self.config['port'],
+            use_ssl=self.config.get('use_ssl', False),
             **dict(self.DEFAULT_SERVER_ARGS, **server_args),
             # wu stuff:
             # get_info=ldap3.SCHEMA,
@@ -145,7 +146,6 @@ class HssLdapConnector(BaseLdapConnector):
     config = HssConfigProxy()
 
     DEFAULT_SERVER_ARGS = {
-        'use_ssl': True,
         'get_info': ldap3.GET_ALL_INFO,
     }
     DEFAULT_CONNECT_ARGS = {

--- a/sipa/model/hss/ldap.py
+++ b/sipa/model/hss/ldap.py
@@ -36,6 +36,10 @@ class BaseLdapConnector(ldap3.Connection, metaclass=ABCMeta):
         The bind uses what `type(self).config` provides as data.
 
         Can be used as ContextManager as well.
+
+        :raises: ValueError if not password and not username
+        :raises: InvalidCredentials if not password
+        :raises: InvalidCredentials if bind sais so
         """
         self.username = username
         self.password = password

--- a/sipa/model/hss/ldap.py
+++ b/sipa/model/hss/ldap.py
@@ -102,10 +102,6 @@ class HssConfigProxy:
         return {
             'host': conf['HSS_LDAP_HOST'],
             'port': int(conf['HSS_LDAP_PORT']),
-            # 'user': conf['WU_LDAP_SEARCH_USER'],
-            'password': conf['WU_LDAP_SEARCH_PASSWORD'],
-            # 'search_user_base': conf['HSS_SEARCH_USER_BASE'],
-            # 'search_group_base': conf['WU_LDAP_SEARCH_GROUP_BASE'],
             'userdn_format': current_app.config['HSS_LDAP_USERDN_FORMAT'],
         }
 

--- a/sipa/model/hss/ldap.py
+++ b/sipa/model/hss/ldap.py
@@ -1,3 +1,5 @@
+from abc import ABCMeta, abstractmethod
+
 import ldap3
 
 from flask import current_app
@@ -18,3 +20,120 @@ def get_ldap_connection(user, password, use_ssl=True):
                             client_strategy=ldap3.STRATEGY_SYNC,
                             user=user_dn, password=password,
                             authentication=ldap3.AUTH_SIMPLE)
+
+
+class BaseLdapConnector(ldap3.Connection, metaclass=ABCMeta):
+    """This class is a wrapper for an ldap3 Connection."""
+
+    def __init__(self, username=None, password=None):
+        """Return an `ldap3.Connection` object.
+
+        The bind uses what `{type}.`
+
+        Can be used as ContextManager as well.
+        """.format(type=type(self))
+        self.username = username
+        self.password = password
+
+        if not password and not username:
+            # Attempt an anonymous bind, don't use the username
+            bind_user, bind_password = self.get_anonymous_bind_credentials()
+        elif not password and username:
+            raise ValueError("Bind attempted with username without a password")
+        else:
+            bind_user, bind_password = self.get_bind_credentials(username, password)
+
+        self.server = ldap3.Server(
+            host=self.config['host'],
+            port=self.config['port'],
+            # hss stuff:
+            use_ssl=True,  # should be passable via __init__
+            get_info=ldap3.GET_ALL_INFO,
+            # wu stuff:
+            # get_info=ldap3.SCHEMA,
+            # tls=None,  # accept any certificate
+            # connect_timeout=5,
+        )
+
+        try:
+            super().__init__(
+                server=self.server,
+                user=bind_user,
+                password=bind_password,
+                # hss stuff:
+                auto_bind=True,
+                client_strategy=ldap3.STRATEGY_SYNC,
+                authentication=ldap3.AUTH_SIMPLE,
+                # don't
+                # check_names=True,
+                # raise_exceptions=True,
+                # auto_bind=ldap3.AUTO_BIND_TLS_BEFORE_BIND,
+            )
+        except ldap3.LDAPBindError:
+            raise NotImplementedError
+
+    @staticmethod
+    def fetch_user(self, username):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def config(self):
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_bind_credentials(self):
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_anonymous_bind_credentials(self):
+        raise NotImplementedError
+
+
+class HssConfigProxy:
+    def __get__(self, obj, objtype):
+        try:
+            conf = current_app.config
+        except RuntimeError:
+            return {}
+        return {
+            'host': conf['HSS_LDAP_HOST'],
+            'port': int(conf['HSS_LDAP_PORT']),
+            # 'user': conf['WU_LDAP_SEARCH_USER'],
+            'password': conf['WU_LDAP_SEARCH_PASSWORD'],
+            # 'search_user_base': conf['HSS_SEARCH_USER_BASE'],
+            # 'search_group_base': conf['WU_LDAP_SEARCH_GROUP_BASE'],
+            'userdn_format': current_app.config['HSS_LDAP_USERDN_FORMAT'],
+        }
+
+
+class HssLdapConnector(BaseLdapConnector):
+    config = HssConfigProxy()
+
+    def get_anonymous_bind_credentials(self):
+        raise ValueError("The Hss Connector doesn't support Anonymous Binding")
+
+    def get_bind_credentials(self, username, password):
+        """Return the according userdn of `username` and the given password"""
+        return self.config['userdn_format'].format(user=username), password
+
+
+def search_in_group():
+    """
+    (with Conn(username) as l:)
+    """
+    raise NotImplementedError
+
+
+def change_email():
+    """
+    (with Conn(username, pw) as l:)
+    """
+    raise NotImplementedError
+
+
+def change_password():
+    """
+    (with Conn(username, pw) as l:)
+    """
+    raise NotImplementedError

--- a/sipa/model/hss/ldap.py
+++ b/sipa/model/hss/ldap.py
@@ -31,10 +31,10 @@ class BaseLdapConnector(ldap3.Connection, metaclass=ABCMeta):
                  server_args={}, connect_args={}):
         """Return an `ldap3.Connection` object.
 
-        The bind uses what `{type}.`
+        The bind uses what `type(self).config` provides as data.
 
         Can be used as ContextManager as well.
-        """.format(type=type(self))
+        """
         self.username = username
         self.password = password
 

--- a/sipa/model/hss/ldap.py
+++ b/sipa/model/hss/ldap.py
@@ -108,9 +108,9 @@ class HssConfigProxy:
         return {
             'host': conf['HSS_LDAP_HOST'],
             'port': int(conf['HSS_LDAP_PORT']),
-            'userdn_format': current_app.config['HSS_LDAP_USERDN_FORMAT'],
-            'system_bind': current_app.config['HSS_LDAP_SYSTEM_BIND'],
-            'system_password': current_app.config['HSS_LDAP_SYSTEM_PASSWORD'],
+            'userdn_format': conf['HSS_LDAP_USERDN_FORMAT'],
+            'system_bind': conf['HSS_LDAP_SYSTEM_BIND'],
+            'system_password': conf['HSS_LDAP_SYSTEM_PASSWORD'],
         }
 
 

--- a/sipa/model/hss/ldap.py
+++ b/sipa/model/hss/ldap.py
@@ -40,7 +40,7 @@ class BaseLdapConnector(ldap3.Connection, metaclass=ABCMeta):
 
         if not password and not username:
             # Attempt an anonymous bind, don't use the username
-            bind_user, bind_password = self.get_anonymous_bind_credentials()
+            bind_user, bind_password = self.get_system_bind_credentials()
         elif not password and username:
             raise InvalidCredentials("Bind attempted with username without a password")
         else:
@@ -86,7 +86,7 @@ class BaseLdapConnector(ldap3.Connection, metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    def get_anonymous_bind_credentials(self):
+    def get_system_bind_credentials(self):
         raise NotImplementedError
 
     DEFAULT_CONNECT_ARGS = {}
@@ -119,7 +119,7 @@ class HssLdapConnector(BaseLdapConnector):
         'authentication': ldap3.AUTH_SIMPLE,
     }
 
-    def get_anonymous_bind_credentials(self):
+    def get_system_bind_credentials(self):
         raise ValueError("The Hss Connector doesn't support Anonymous Binding")
 
     def get_bind_credentials(self, username, password):

--- a/sipa/model/hss/ldap.py
+++ b/sipa/model/hss/ldap.py
@@ -111,6 +111,7 @@ class HssConfigProxy:
             'userdn_format': conf['HSS_LDAP_USERDN_FORMAT'],
             'system_bind': conf['HSS_LDAP_SYSTEM_BIND'],
             'system_password': conf['HSS_LDAP_SYSTEM_PASSWORD'],
+            'search_base': conf['HSS_LDAP_SEARCH_BASE'],
         }
 
 

--- a/sipa/model/hss/user.py
+++ b/sipa/model/hss/user.py
@@ -26,8 +26,7 @@ class User(BaseUser):
         :param name: The real name gotten from the LDAP
         """
         self.uid = uid
-        if name is not None:
-            self._realname = name
+        self._realname = name
 
     def __eq__(self, other):
         return self.uid == other.uid and self.datasource == other.datasource
@@ -119,6 +118,8 @@ class User(BaseUser):
 
     @active_prop
     def realname(self):
+        if self._realname is None:
+            return
         return self._realname
 
     @active_prop

--- a/sipa/model/hss/user.py
+++ b/sipa/model/hss/user.py
@@ -3,10 +3,12 @@ from ..default import BaseUser
 from flask.ext.login import AnonymousUserMixin
 
 from sipa.model.property import active_prop, unsupported_prop
+from sipa.model.hss.ldap import HssLdapConnector
 from sipa.utils import argstr
 
 
 class User(BaseUser):
+    LdapConnector = HssLdapConnector
 
     def __init__(self, uid):
         """Initialize the User object.
@@ -56,6 +58,7 @@ class User(BaseUser):
     @classmethod
     def authenticate(cls, username, password):
         """Return a User instance or raise PasswordInvalid"""
+        user_dict = cls.LdapConnector.fetch_user(username)
         # TODO: check password / user
         return cls(username)
 

--- a/sipa/model/property.py
+++ b/sipa/model/property.py
@@ -101,13 +101,12 @@ class ActiveProperty(PropertyBase):
         )
 
     def __repr__(self):
-        return "{}.{}({})".format(__name__, type(self).__name__, argstr(
+        return "<{cls} {name}='{value}' [{empty}]>".format(
+            cls=type(self).__name__,
             name=self.name,
             value=self.value,
-            capabilities=self.capabilities,
-            style=self.style,
-            empty=self.empty,
-        ))
+            empty=('empty' if self.empty else 'nonempty'),
+        )
 
 
 def unsupported_prop(func):

--- a/sipa/utils/exceptions.py
+++ b/sipa/utils/exceptions.py
@@ -7,11 +7,15 @@ OperationalError for MySQL and SERVER_DOWN for LDAP are global app handlers!
 """
 
 
-class UserNotFound(Exception):
+class InvalidCredentials(Exception):
     pass
 
 
-class PasswordInvalid(Exception):
+class UserNotFound(InvalidCredentials):
+    pass
+
+
+class PasswordInvalid(InvalidCredentials):
     pass
 
 

--- a/tests/integration/test_hss_ldap.py
+++ b/tests/integration/test_hss_ldap.py
@@ -251,7 +251,6 @@ class AuthenticateTestCase(SimpleLdapUserTestBase):
         self.assertIsInstance(user, AnonymousUserMixin)
 
 
-@unittest.expectedFailure
 class GetTestCase(SimpleLdapUserTestBase):
     def test_correct_user_passed(self):
         user = User.get(self.username)

--- a/tests/integration/test_hss_ldap.py
+++ b/tests/integration/test_hss_ldap.py
@@ -1,6 +1,7 @@
 from functools import partial
-from unittest import TestCase, expectedFailure
+from unittest import TestCase
 
+from flask.ext.login import AnonymousUserMixin
 import ldap3
 from ldap3.core.exceptions import LDAPPasswordIsMandatoryError, LDAPBindError
 
@@ -204,15 +205,11 @@ class MightBeLdapDNTestCase(TestCase):
 class AuthenticateTestCase(SimpleLdapTestBase):
     def setUp(self):
         super().setUp()
-        self.user = User.authenticate(self.username, self.password)
-
-    def test_authenticate_returns_userdata(self):
-        # TODO: decide: isn't there a better method to patch?
-        self.assertIsInstance(self.user, User)
 
     def test_user_data_passed(self):
+        user = User.authenticate(self.username, self.password)
         self.assert_user_data_passed(
-            user=self.user,
+            user=user,
             login=self.username,
             name=self.user_dict['gecos'],
         )

--- a/tests/integration/test_hss_ldap.py
+++ b/tests/integration/test_hss_ldap.py
@@ -21,6 +21,8 @@ class HssLdapAppInitialized(AppInitialized):
             'HSS_LDAP_HOST': self.LDAP_HOST,
             'HSS_LDAP_PORT': self.LDAP_PORT,
             'HSS_LDAP_USERDN_FORMAT': self.LDAP_USER_FORMAT_STRING,
+            'HSS_LDAP_SYSTEM_BIND': self.LDAP_ADMIN_UID,
+            'HSS_LDAP_SYSTEM_PASSWORD': self.LDAP_ADMIN_PASSWORD,
         })
 
 
@@ -158,8 +160,16 @@ class HssLdapConnectorTestCase(SimpleLdapTestBase):
             pass
 
     def test_anonymous_bind_raises(self):
+        """Test connecting without username and password raises a ValueError"""
         with self.assertRaises(ValueError), self.Connector():
             pass
+
+    def test_system_bind_successful(self):
+        try:
+            with self.Connector.system_bind():
+                pass
+        except LDAPBindError:
+            self.fail("LDAPBindError thrown instead of successful bind!")
 
     def test_empty_password_bind_raises(self):
         with self.assertRaises(InvalidCredentials), \

--- a/tests/integration/test_hss_ldap.py
+++ b/tests/integration/test_hss_ldap.py
@@ -93,7 +93,11 @@ class LdapSetupMixin:
                                                  desc=description))
 
 
-class SimpleLdapBindTestCase(LdapSetupMixin, OneLdapUserFixture, HssLdapAppInitialized):
+class SimpleLdapTestBase(LdapSetupMixin, OneLdapUserFixture, HssLdapAppInitialized):
+    pass
+
+
+class SimpleLdapBindTestCase(SimpleLdapTestBase):
     ldap_connect = partial(get_ldap_connection, use_ssl=False)
 
     def __init__(self, *args, **kwargs):

--- a/tests/integration/test_hss_ldap.py
+++ b/tests/integration/test_hss_ldap.py
@@ -24,6 +24,7 @@ class HssLdapAppInitialized(AppInitialized):
             'HSS_LDAP_USERDN_FORMAT': self.LDAP_USER_FORMAT_STRING,
             'HSS_LDAP_SYSTEM_BIND': self.LDAP_ADMIN_UID,
             'HSS_LDAP_SYSTEM_PASSWORD': self.LDAP_ADMIN_PASSWORD,
+            'HSS_LDAP_SEARCH_BASE': self.LDAP_USER_BASE
         })
 
 

--- a/tests/integration/test_hss_ldap.py
+++ b/tests/integration/test_hss_ldap.py
@@ -96,7 +96,11 @@ class LdapSetupMixin:
 
 
 class SimpleLdapTestBase(LdapSetupMixin, OneLdapUserFixture, HssLdapAppInitialized):
-    pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.username = next(iter(self.fixtures.keys()))
+        self.password = self.fixtures[self.username]['userPassword']
+        self.user_dict = self.fixtures[self.username]
 
 
 class GetLdapConnectionTestCase(SimpleLdapTestBase):
@@ -105,11 +109,6 @@ class GetLdapConnectionTestCase(SimpleLdapTestBase):
     May be deleted, just as said function.
     """
     ldap_connect = partial(get_ldap_connection, use_ssl=False)
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.username = next(iter(self.fixtures.keys()))
-        self.password = self.fixtures[self.username]['userPassword']
 
     def test_ldap_password_required(self):
         with self.assertRaises(LDAPPasswordIsMandatoryError):
@@ -143,11 +142,6 @@ class TestingHssLdapConnector(HssLdapConnector):
 
 class HssLdapConnectorTestCase(SimpleLdapTestBase):
     Connector = TestingHssLdapConnector
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.username = next(iter(self.fixtures.keys()))
-        self.password = self.fixtures[self.username]['userPassword']
 
     def test_connector_works(self):
         with self.Connector(self.username, self.password):

--- a/tests/integration/test_hss_ldap.py
+++ b/tests/integration/test_hss_ldap.py
@@ -99,7 +99,7 @@ class SimpleLdapTestBase(LdapSetupMixin, OneLdapUserFixture, HssLdapAppInitializ
     pass
 
 
-class SimpleLdapBindTestCase(SimpleLdapTestBase):
+class GetLdapConnectionTestCase(SimpleLdapTestBase):
     """Tests for the `get_ldap_connecton` function.
 
     May be deleted, just as said function.

--- a/tests/integration/test_hss_ldap.py
+++ b/tests/integration/test_hss_ldap.py
@@ -3,7 +3,7 @@ from functools import partial
 import ldap3
 from ldap3.core.exceptions import LDAPPasswordIsMandatoryError, LDAPBindError
 
-from sipa.model.hss.ldap import get_ldap_connection
+from sipa.model.hss.ldap import get_ldap_connection, HssLdapConnector
 from tests.prepare import AppInitialized
 
 
@@ -122,3 +122,17 @@ class SimpleLdapBindTestCase(SimpleLdapTestBase):
             self.ldap_connect(self.username, self.password)
         except LDAPBindError:
             self.fail("LDAPBindError thrown instead of successful bind!")
+
+
+class HssLdapConnectorTestCase(SimpleLdapTestBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.username = next(iter(self.fixtures.keys()))
+        self.password = self.fixtures[self.username]['userPassword']
+
+    def test_connector_abstract(self):
+        try:
+            HssLdapConnector(self.username, self.password)
+        except TypeError as e:
+            self.assertIn('with abstract methods', e.args[0])
+            self.fail(e.args[0])

--- a/tests/integration/test_hss_ldap.py
+++ b/tests/integration/test_hss_ldap.py
@@ -210,7 +210,6 @@ class AuthenticateTestCase(SimpleLdapTestBase):
         # TODO: decide: isn't there a better method to patch?
         self.assertIsInstance(self.user, User)
 
-    @expectedFailure
     def test_user_data_passed(self):
         self.assert_user_data_passed(
             user=self.user,

--- a/tests/integration/test_hss_ldap.py
+++ b/tests/integration/test_hss_ldap.py
@@ -222,3 +222,11 @@ class AuthenticateTestCase(SimpleLdapTestBase):
         self.assertEqual(user.realname, name)
         # We don't mind the rest of the data
         # …We only test the ldap here.
+
+    def test_invalid_password_anonymous(self):
+        user = User.authenticate(self.username, self.password + 'wrong')
+        self.assertIsInstance(user, AnonymousUserMixin)
+
+    def test_invalid_username_anonymous(self):
+        user = User.authenticate(self.username + 'wrong', self.password)
+        self.assertIsInstance(user, AnonymousUserMixin)

--- a/tests/integration/test_hss_ldap.py
+++ b/tests/integration/test_hss_ldap.py
@@ -226,9 +226,6 @@ class MightBeLdapDNTestCase(TestCase):
 
 
 class AuthenticateTestCase(SimpleLdapTestBase):
-    def setUp(self):
-        super().setUp()
-
     def test_user_data_passed(self):
         user = User.authenticate(self.username, self.password)
         self.assert_user_data_passed(

--- a/tests/integration/test_hss_ldap.py
+++ b/tests/integration/test_hss_ldap.py
@@ -100,6 +100,10 @@ class SimpleLdapTestBase(LdapSetupMixin, OneLdapUserFixture, HssLdapAppInitializ
 
 
 class SimpleLdapBindTestCase(SimpleLdapTestBase):
+    """Tests for the `get_ldap_connecton` function.
+
+    May be deleted, just as said function.
+    """
     ldap_connect = partial(get_ldap_connection, use_ssl=False)
 
     def __init__(self, *args, **kwargs):

--- a/tests/integration/test_hss_ldap.py
+++ b/tests/integration/test_hss_ldap.py
@@ -61,8 +61,9 @@ class LdapSetupMixin:
     def delete_everything_below_base(self):
         """Delete the LDAP_USER_BASE dn and every entry below it."""
         self.conn.search(self.LDAP_USER_BASE, '(objectclass=*)')
-        for entry in self.conn.entries:
-            self.conn.delete(entry.entry_get_dn())
+        if self.conn.entries:
+            for entry in self.conn.entries:
+                self.conn.delete(entry.entry_get_dn())
 
         self.conn.delete(self.LDAP_USER_BASE)
 


### PR DESCRIPTION
- [x] Run the tests and see them pass – **important, since travis can't do the full docker setup (yet)!**
- [x] Rebase your branch on top of <s>`develop`</s> `hss`
- [x] Include tests for features you introduced / bugs you fixed

This PR allows an LDAP backend to be used in SIPA for the HSS datasource.

Things to do:
- [x] Raw backend (connector)
- [x] Extended backend (methods as in Wu module, if useful!) _(checked: The methods are useless for this module)_
- [x] `def authenticate`
- [x] `def get` (8a0c7a4db63c795cf18df788ffdc5ffd5af062c1)

Fixes #238 