### PR TITLE
Make `address` key optional

### DIFF
--- a/sipa/model/gerok/user.py
+++ b/sipa/model/gerok/user.py
@@ -83,7 +83,7 @@ class User(BaseUser):
 
         self._id = user_data['id']
         self._login = user_data['login']
-        self._address = user_data['address']
+        self._address = user_data.get('address', '')
         self._mail = user_data['mail']
         self._status = user_data['status']
         self.name = user_data['name']

--- a/tests/model/test_gerok.py
+++ b/tests/model/test_gerok.py
@@ -260,7 +260,7 @@ def get_possible_users():
             'password': "".join(reversed(str(i))),
             'name': "User {}".format(i),
             'status': "OK",
-            'address': "Gerokstraße 38",
+            **({'address': "Gerokstraße 38"} if i % 2 else {}),
             'hosts': [
                 generate_host(3*i + j)
                 for j in range(i % 3)
@@ -320,7 +320,7 @@ class TestGerokUser(AppInitialized):
         self.assertEqual(user.uid, user_data['login'])
         self.assertEqual(user.id, user_data['id'])
         self.assertEqual(user.login, user_data['login'])
-        self.assertEqual(user.address, user_data['address'])
+        self.assertEqual(user.address, user_data.get('address', ''))
         if user_data['mail']:
             self.assertEqual(user.mail, user_data['mail'])
         else:


### PR DESCRIPTION
Since sometimes, the API response may just not contain an 'address' key,
the API should be able to handle this.

This adds a quick test for a missing 'address' key and uses `get()` to
retrieve it instead of `__getitem__`.

Proposing merge into `master` and Tag 0.3.1