### PR TITLE
Update visual news seperation

### DIFF
--- a/sipa/static/css/style.css
+++ b/sipa/static/css/style.css
@@ -2,6 +2,15 @@
 	display: none;
 }
 
+.newsblock {
+	margin-bottom: 40px;
+}
+
+hr {
+	margin-bottom: 5px;
+	margin-top: 5px;
+}
+
 body {
 	padding-top: 50px;
 }

--- a/sipa/templates/index.html
+++ b/sipa/templates/index.html
@@ -41,7 +41,7 @@
             </small>
         </a>
         <hr />
-        <div>{{ art.html|safe }}</div>
+        <div class="newsblock">{{ art.html|safe }}</div>
 
     {%- endfor %}{%- else -%}
         <div class="alert alert-info">


### PR DESCRIPTION
Adds spacing between news blocks and reduces spacing between headline and news content.

This makes it clearer what belongs to which news imo.

![news](https://cloud.githubusercontent.com/assets/2026103/19782495/527bb3de-9c8e-11e6-8321-37dc11a02e6f.png)