### PR TITLE
Implement restricted pages and documents

### DIFF
--- a/sipa/blueprints/documents.py
+++ b/sipa/blueprints/documents.py
@@ -3,16 +3,21 @@
 import os
 
 from flask import Blueprint, send_from_directory, current_app
+from flask_login import current_user
 from flask.views import View
 
 bp_documents = Blueprint('documents', __name__)
 
 
 class StaticFiles(View):
-    def __init__(self, directory):
+    def __init__(self, directory, login_required=False):
         self.directory = directory
+        self.login_required = login_required
 
     def dispatch_request(self, filename):
+        if self.login_required and not current_user.is_authenticated:
+            return current_app.login_manager.unauthorized()
+
         if os.path.isabs(self.directory):
             directory = self.directory
         else:
@@ -30,3 +35,9 @@ bp_documents.add_url_rule('/images/<path:filename>',
 bp_documents.add_url_rule('/documents/<path:filename>',
                           view_func=StaticFiles.as_view('show_document',
                                                         '../content/documents'))
+
+
+bp_documents.add_url_rule('/documents/restricted/<path:filename>',
+                          view_func=StaticFiles.as_view('show_document_restricted',
+                                                        '../content/documents/restricted',
+                                                        True))

--- a/sipa/blueprints/pages.py
+++ b/sipa/blueprints/pages.py
@@ -9,6 +9,7 @@ from logging import getLogger
 import json
 
 from flask import Blueprint, render_template, current_app
+from flask_login import current_user
 
 from sipa.flatpages import cf_pages
 from sipa.model import backends
@@ -27,6 +28,13 @@ def show(category_id, article_id):
     dormitory and see _specific_ information like financial data.
     """
     article = cf_pages.get_or_404(category_id, article_id)
+
+    try:
+        restricted = article.restricted
+    except AttributeError:
+        restricted = False
+    if restricted and not current_user.is_authenticated:
+        return current_app.login_manager.unauthorized()
 
     box_filename = os.path.join(
         os.path.abspath(current_app.config['FLATPAGES_ROOT']),


### PR DESCRIPTION
Instead of only publishing a few minutes, we want to make all minutes available _to our members_. This merge request should prepare Sipa for this change by

 - introducing a restricted documents area where the authentication of the user is checked
 - introducing a new meta field that flags the FlatPage as restricted

Up to now I did the following:

- [ ] Run the tests and see them pass
- [x] Rebase your branch on top of `develop`
- [ ] Include tests for features you introduced / bugs you fixed
