### PR TITLE
Switch to sql for Wu realnames, fix #329.

### DIFF
--- a/sipa/model/wu/factories.py
+++ b/sipa/model/wu/factories.py
@@ -26,6 +26,8 @@ class NutzerFactory(WuFactory):
         model = Nutzer
 
     nutzer_id = Sequence(lambda n: n)
+    name = FuzzyChoice({"Peterson", "Schmidt Wolf", "Huang"})
+    vname = FuzzyChoice({"Lee", "Lars", "Daniel Garcia"})
     wheim = SubFactory(WheimFactory)
     etage = FuzzyInteger(1, 15)
     zimmernr = FuzzyChoice(str(x) for x in range(11, 56))

--- a/sipa/model/wu/schema.py
+++ b/sipa/model/wu/schema.py
@@ -43,6 +43,8 @@ class Nutzer(db.Model):
     )
 
     nutzer_id = Column(Integer, primary_key=True, server_default=text("'0'"))
+    name = Column(String(40), nullable=False, server_default=text("''"))
+    vname = Column(String(40), nullable=False, server_default=text("''"))
     wheim_id = Column(Integer, ForeignKey('wheim.wheim_id'), nullable=False, index=True,
                       server_default=text("'0'"))
     wheim = relationship('Wheim')

--- a/sipa/model/wu/user.py
+++ b/sipa/model/wu/user.py
@@ -33,9 +33,8 @@ class User(BaseUser):
     the terms 'uid' and 'username' refer to the same thing.
     """
 
-    def __init__(self, uid, realname, mail):
+    def __init__(self, uid, mail):
         super().__init__(uid)
-        self._realname = realname
         self.group = self.define_group()
         self._mail = mail
         self._userdb = UserDB(self)
@@ -43,12 +42,11 @@ class User(BaseUser):
     def __repr__(self):
         return "{}.{}({})".format(__name__, type(self).__name__, argstr(
             uid=self.uid,
-            realname=self._realname,
             mail=self._mail,
         ))
 
     def __str__(self):
-        return "User {} ({}), {}".format(self._realname, self.uid, self.group)
+        return "User {}, {}".format(self.uid, self.group)
 
     can_change_password = True
 
@@ -68,7 +66,7 @@ class User(BaseUser):
         """
         user = LdapConnector.fetch_user(username)
         if user:
-            return cls(user['uid'], user['name'], user['mail'], **kwargs)
+            return cls(user['uid'], user['mail'], **kwargs)
         return AnonymousUserMixin()
 
     @classmethod
@@ -234,7 +232,7 @@ class User(BaseUser):
 
     @active_prop
     def realname(self):
-        return self._realname
+        return self._nutzer.vname + " " + self._nutzer.name
 
     @active_prop
     @connection_dependent

--- a/tests/integration/test_wu.py
+++ b/tests/integration/test_wu.py
@@ -44,12 +44,11 @@ class WuAtlantisFakeDBInitialized(WuFrontendTestBase):
         self.assertIn(computer.c_alias, user.hostalias)
 
     @staticmethod
-    def create_user_ldap_patched(uid, name, mail):
+    def create_user_ldap_patched(uid, mail):
         with patch('sipa.model.wu.user.search_in_group',
                    MagicMock(return_value=False)):
             return User(
                 uid=uid,
-                realname=name,
                 mail=mail,
             )
 
@@ -113,7 +112,6 @@ class UserNoComputersTestCase(WuAtlantisFakeDBInitialized):
         self.nutzer = NutzerFactory.create()
         self.user = self.create_user_ldap_patched(
             uid=self.nutzer.unix_account,
-            name=None,
             mail=None,
         )
 
@@ -131,12 +129,10 @@ class TestUserInitializedCase(WuAtlantisFakeDBInitialized):
         self.nutzer = NutzerFactory.create(status=1)
         self.computers = ComputerFactory.create_batch(20, nutzer=self.nutzer)
 
-        self.name = "Test Nutzer"
         self.mail = "foo@bar.baz"
 
         self.user = self.create_user_ldap_patched(
             uid=self.nutzer.unix_account,
-            name=self.name,
             mail=self.mail,
         )
 
@@ -150,6 +146,10 @@ class TestUserInitializedCase(WuAtlantisFakeDBInitialized):
 
     def test_address_passed(self):
         self.assertEqual(self.user.address, self.nutzer.address)
+
+    def test_realname_passed(self):
+        original_realname = self.nutzer.vname + " " + self.nutzer.name
+        self.assertEqual(self.user.realname, original_realname)
 
     def test_id_passed(self):
         original_id = str(self.nutzer.nutzer_id)
@@ -172,7 +172,6 @@ class ComputerWithoutAliasTestCase(WuAtlantisFakeDBInitialized):
 
         self.user = self.create_user_ldap_patched(
             uid=self.nutzer.unix_account,
-            name=self.name,
             mail=self.mail,
         )
 
@@ -211,7 +210,6 @@ class UserStatusGivenCorrectly(WuAtlantisFakeDBInitialized):
         for nutzer in self.unknown_status_nutzer_list:
             user = self.create_user_ldap_patched(
                 uid=nutzer.unix_account,
-                name=None,
                 mail=None,
             )
             with self.subTest(user=user):
@@ -221,7 +219,6 @@ class UserStatusGivenCorrectly(WuAtlantisFakeDBInitialized):
         for nutzer in self.valid_status_nutzer_list:
             user = self.create_user_ldap_patched(
                 uid=nutzer.unix_account,
-                name=None,
                 mail=None,
             )
             with self.subTest(user=user):
@@ -238,7 +235,6 @@ class CorrectUserHasConnection(WuAtlantisFakeDBInitialized):
         for nutzer in self.connection_nutzer_list:
             user = self.create_user_ldap_patched(
                 uid=nutzer.unix_account,
-                name=None,
                 mail=None
             )
             with self.subTest(user=user):
@@ -248,7 +244,6 @@ class CorrectUserHasConnection(WuAtlantisFakeDBInitialized):
         for nutzer in self.no_connection_nutzer_list:
             user = self.create_user_ldap_patched(
                 uid=nutzer.unix_account,
-                name=None,
                 mail=None,
             )
             with self.subTest(user=user):
@@ -273,7 +268,6 @@ class CreditTestCase(OneUserWithCredit):
     def test_credit_passed(self):
         fetched_user = self.create_user_ldap_patched(
             uid=self.nutzer.unix_account,
-            name=None,
             mail=None,
         )
         expected_credit = self.credit_entries[-1].amount
@@ -282,7 +276,6 @@ class CreditTestCase(OneUserWithCredit):
     def test_credit_appears_in_history(self):
         fetched_history = self.create_user_ldap_patched(
             uid=self.nutzer.unix_account,
-            name=None,
             mail=None,
         ).traffic_history
         # the history is ascending, but wee ned a zip ending at
@@ -306,7 +299,6 @@ class TrafficOneComputerTestCase(OneUserWithCredit):
     def test_traffic_data_passed(self):
         fetched_history = self.create_user_ldap_patched(
             uid=self.nutzer.unix_account,
-            name=None,
             mail=None,
         ).traffic_history
         # the history is ascending, but wee ned a zip ending at
@@ -343,7 +335,6 @@ class FinanceBalanceTestCase(OneUserWithCredit):
         db.session.commit()
         self.user = self.create_user_ldap_patched(
             uid=self.nutzer.unix_account,
-            name=None,
             mail=None,
         )
         self.finance_info = self.user.finance_information
@@ -395,7 +386,6 @@ class HabenSollSwitchedTestCase(OneUserWithCredit):
         db.session.commit()
         self.user = self.create_user_ldap_patched(
             uid=self.nutzer.unix_account,
-            name=None,
             mail=None,
         )
 
@@ -410,7 +400,6 @@ class NoInternetByRentalTestCase(WuAtlantisFakeDBInitialized):
         self.nutzer = NutzerFactory()
         self.user = self.create_user_ldap_patched(
             uid=self.nutzer.unix_account,
-            name=None,
             mail=None,
         )
 
@@ -424,7 +413,6 @@ class InternetByRentalTestCase(WuAtlantisFakeDBInitialized):
         self.nutzer = NutzerFactory(internet_by_rental=True)
         self.user = self.create_user_ldap_patched(
             uid=self.nutzer.unix_account,
-            name=None,
             mail=None,
         )
 

--- a/tests/model/test_wu.py
+++ b/tests/model/test_wu.py
@@ -15,7 +15,6 @@ class UserNoDBTestCase(TestCase):
         self.userdb_mock.reset_mock()
 
     def assert_userdata_passed(self, user, user_dict):
-        self.assertEqual(user.realname, user_dict['name'])
         self.assertEqual(user.group, user_dict.get('group', 'passive'))
         self.assertEqual(user.mail, user_dict['mail'])
 
@@ -30,7 +29,6 @@ class UserNoDBTestCase(TestCase):
     def test_explicit_init(self):
         sample_user = {
             'uid': 'testnutzer',
-            'name': "Test Nutzer",
             'mail': "test@nutzer.de",
             'group': 'passive',
         }
@@ -38,7 +36,6 @@ class UserNoDBTestCase(TestCase):
         with self.patch_user_group(sample_user):
             user = User(
                 uid=sample_user['uid'],
-                realname=sample_user['name'],
                 mail=sample_user['mail'],
             )
 
@@ -65,7 +62,7 @@ class UserNoDBTestCase(TestCase):
         for uid, group in sample_users.items():
             with patch('sipa.model.wu.user.search_in_group',
                        fake_search_in_group):
-                user = User(uid=uid, realname="", mail="")
+                user = User(uid=uid, mail="")
                 with self.subTest(user=user):
                     self.assertEqual(user.define_group(), group)
         return
@@ -73,9 +70,9 @@ class UserNoDBTestCase(TestCase):
     @patch('sipa.model.wu.user.UserDB', userdb_mock)
     def test_get_constructor(self):
         test_users = [
-            {'uid': "uid1", 'name': "Name Eins", 'mail': "test@foo.bar"},
-            {'uid': "uid2", 'name': "Mareike Musterfrau", 'mail': "test@foo.baz"},
-            {'uid': "uid3", 'name': "Deine Mutter", 'mail': "shizzle@damn.onion"},
+            {'uid': "uid1", 'mail': "test@foo.bar"},
+            {'uid': "uid2", 'mail': "test@foo.baz"},
+            {'uid': "uid3", 'mail': "shizzle@damn.onion"},
         ]
 
         for test_user in test_users:


### PR DESCRIPTION
`realname` is now fetched from the Wu sql database, which should preferred over LDAP since it is easier and more frequently edited, and the LDAP is not synced against it.

- [x] Run the tests and see them pass
- [x] Rebase your branch on top of `develop`
- [x] Include tests for features you introduced / bugs you fixed

This fixes issue #329.
