### PR TITLE
Display negative numbers in proper units, fix #335.

### DIFF
--- a/build/requirements/requirements.txt
+++ b/build/requirements/requirements.txt
@@ -6,7 +6,7 @@ Flask-Script==2.0.3
 SQLAlchemy==1.0.8
 Flask-SQLAlchemy==2.1
 raven==5.7.1
-ldap3==2.2.2
+ldap3==2.3
 requests==2.7.0
 Flask-FlatPages==0.6
 pygal==2.0.6

--- a/sipa/units.py
+++ b/sipa/units.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8; -*-
 from functools import wraps
+from math import log, floor
 
 
 #: 0 divisions mean the unit stays being `KiB`.
@@ -31,11 +32,15 @@ def max_divisions(number, base=1024, unit_list=None):
     """
     if unit_list is None:
         unit_list = UNIT_LIST
-    divisions = 0
-    while number >= base and divisions < len(UNIT_LIST)-1:
-        number /= base
-        divisions += 1
-    return divisions
+
+    # Determine largest whole logarithm of absolute value
+    divisions = floor(log(abs(number), base))
+
+    # Make sure we have enough units available
+    if divisions < len(unit_list):
+        return divisions
+    else:
+        return len(unit_list) - 1
 
 
 def reduce_by_base(number, divisions, base=1024):

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -27,7 +27,8 @@ class ThingsWithBasesTestCase(TestCase):
         """Test `max_divisions()` for basic cases"""
         for base in self.BASES:
             with self.subTest(base=base):
-                example = [(1, 0), (base / 2, 0), (base, 1), (2 * base, 1), (base**2, 2)]
+                example = [(1, 0), (base / 2, 0), (base, 1), (2 * base, 1), (base**2, 2),
+                           (-base / 2, 0), (-base, 1), (-2 * base, 1), (-(base**2), 2)]
                 for num, expected_division in example:
                     with self.subTest(num=num):
                         self.assertEqual(max_divisions(num, base=base), expected_division)
@@ -37,7 +38,8 @@ class ThingsWithBasesTestCase(TestCase):
         for base in self.BASES:
             with self.subTest(base=base):
                 # Some trivial examples should be enough
-                examples = [(0, 0), (base, 1), (base**2, base)]
+                examples = [(0, 0), (base, 1), (base**2, base),
+                            (-base, -1), (-(base**2), -base)]
                 for num, result in examples:
                     with self.subTest(num=num):
                         self.assertEqual(


### PR DESCRIPTION
`max_divisions` will now work properly for negative numbers, instead of
always returning 0.

- [x] Run the tests and see them pass
- [x] Rebase your branch on top of `develop`
- [x] Include tests for features you introduced / bugs you fixed