### PR TITLE
Handle numbers near 0 correctly when determining unit

### DIFF
--- a/sipa/units.py
+++ b/sipa/units.py
@@ -34,7 +34,11 @@ def max_divisions(number, base=1024, unit_list=None):
         unit_list = UNIT_LIST
 
     # Determine largest whole logarithm of absolute value
+    if number == 0:
+        return 0
     divisions = floor(log(abs(number), base))
+    if divisions <= 0:
+        return 0
 
     # Make sure we have enough units available
     if divisions < len(unit_list):

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -28,6 +28,7 @@ class ThingsWithBasesTestCase(TestCase):
         for base in self.BASES:
             with self.subTest(base=base):
                 example = [(1, 0), (base / 2, 0), (base, 1), (2 * base, 1), (base**2, 2),
+                           (0, 0), (base**-2, 0), (-(base**-2), 0),
                            (-base / 2, 0), (-base, 1), (-2 * base, 1), (-(base**2), 2)]
                 for num, expected_division in example:
                     with self.subTest(num=num):


### PR DESCRIPTION
My recent implementation of the division calculator didn't account for `num==0` and `num<=base**-1`, this should fix that.

- [x] Run the tests and see them pass
- [x] Rebase your branch on top of `develop`
- [x] Include tests for features you introduced / bugs you fixed