### PR TITLE
Replace locale_preferences with negotiate_locale

### DIFF
--- a/sipa/babel.py
+++ b/sipa/babel.py
@@ -1,28 +1,8 @@
 # -*- coding: utf-8 -*-
-from babel.core import Locale, UnknownLocaleError
+from babel.core import Locale
 
 from flask import request
-from flask_babel import Babel, get_locale
-
-
-def locale_preferences():
-    """Return a list of locales the user accepts
-
-    :returns: A list of locales
-
-    :rtype: List of :py:obj:`Locale` s
-    """
-    main_locale = get_locale()
-    locales = [main_locale]
-
-    def to_locale(language):
-        try:
-            return Locale(language)
-        except UnknownLocaleError:
-            return main_locale
-
-    locales.extend(map(to_locale, iter(request.accept_languages.values())))
-    return locales
+from flask_babel import Babel
 
 
 def possible_locales():


### PR DESCRIPTION
As mentioned in #344 we can replace our custom locale selection with functionality provided by babel.

This PR removes the `locale_preferences` function from the code base and replaces it with `negotiate_locale`.