### PR TITLE
Add hints to contact form

### DIFF
--- a/sipa/static/css/style.css
+++ b/sipa/static/css/style.css
@@ -148,3 +148,11 @@ td {
 img[alt=software_logo] {
 	width: 100px;
 }
+
+#hints {
+	padding: 0;
+}
+
+#hints div {
+	margin-bottom: 10px;
+}

--- a/sipa/static/js/agdsn.js
+++ b/sipa/static/js/agdsn.js
@@ -1,3 +1,7 @@
+function get_language() {
+    return JSON.parse(document.getElementById('locale').innerHTML);
+}
+
 if (window.location.pathname.endsWith("contact")) {
     var hints = [];
     $.getJSON("static/js/hints.json", function (raw_hints) {

--- a/sipa/static/js/agdsn.js
+++ b/sipa/static/js/agdsn.js
@@ -19,12 +19,11 @@ if (window.location.pathname.endsWith("contact")) {
     $.getJSON("static/js/hints.json", function (raw_hints) {
         hints = raw_hints.map(function (hint) {
             return {
-                not_in: hint.not_in,
+                not_in_dorm: hint.not_in_dorm,
                 patterns: hint.patterns.map(function (pattern) {
                     return new RegExp(pattern, "i");
                 }),
-                hint_de: hint.hint_de,
-                hint_en: hint.hint_en
+                hint: hint.hint
             };
         });
     });
@@ -33,14 +32,14 @@ if (window.location.pathname.endsWith("contact")) {
             var contains = hint.patterns.some(function (pattern) {
                 return pattern.test($("#message").val())
             });
-            var not_blacklisted = hint.not_in.every(function (dorm) {
+            var not_blacklisted = hint.not_in_dorm.every(function (dorm) {
                 return dorm !== $("#dormitory").val();
             });
             return contains & not_blacklisted;
         });
         $("#hints").empty();
         applicable.forEach(function (hint) {
-            var hint_text = guess_locale() === "de" ? hint.hint_de : hint.hint_en;
+            var hint_text = hint.hint[guess_locale()];
             $("#hints").append("<div class='alert alert-warning'>" + hint_text + "</div>");
         });
     });

--- a/sipa/static/js/agdsn.js
+++ b/sipa/static/js/agdsn.js
@@ -1,19 +1,3 @@
-function guess_locale() {
-    // the locale defined in a cookie takes precedence
-    if (document.cookie.includes("de")) {
-        return "de"
-    }
-    if (document.cookie.includes("en")) {
-        return "en"
-    }
-
-    // if no cookie is found use the browsers default or english if the default language is not supported
-    if (navigator.language.toLowerCase().includes("de")) {
-        return "de";
-    }
-    return "en";
-}
-
 if (window.location.pathname.endsWith("contact")) {
     var hints = [];
     $.getJSON("static/js/hints.json", function (raw_hints) {
@@ -39,7 +23,7 @@ if (window.location.pathname.endsWith("contact")) {
         });
         $("#hints").empty();
         applicable.forEach(function (hint) {
-            var hint_text = hint.hint[guess_locale()];
+            var hint_text = hint.hint[get_language()];
             $("#hints").append("<div class='alert alert-warning'>" + hint_text + "</div>");
         });
     });

--- a/sipa/static/js/agdsn.js
+++ b/sipa/static/js/agdsn.js
@@ -1,0 +1,47 @@
+function guess_locale() {
+    // the locale defined in a cookie takes precedence
+    if (document.cookie.includes("de")) {
+        return "de"
+    }
+    if (document.cookie.includes("en")) {
+        return "en"
+    }
+
+    // if no cookie is found use the browsers default or english if the default language is not supported
+    if (navigator.language.toLowerCase().includes("de")) {
+        return "de";
+    }
+    return "en";
+}
+
+if (window.location.pathname.endsWith("contact")) {
+    var hints = [];
+    $.getJSON("static/js/hints.json", function (raw_hints) {
+        hints = raw_hints.map(function (hint) {
+            return {
+                not_in: hint.not_in,
+                patterns: hint.patterns.map(function (pattern) {
+                    return new RegExp(pattern, "i");
+                }),
+                hint_de: hint.hint_de,
+                hint_en: hint.hint_en
+            };
+        });
+    });
+    $("#message").keypress(function () {
+        applicable = hints.filter(function (hint) {
+            var contains = hint.patterns.some(function (pattern) {
+                return pattern.test($("#message").val())
+            });
+            var not_blacklisted = hint.not_in.every(function (dorm) {
+                return dorm !== $("#dormitory").val();
+            });
+            return contains & not_blacklisted;
+        });
+        $("#hints").empty();
+        applicable.forEach(function (hint) {
+            var hint_text = guess_locale() === "de" ? hint.hint_de : hint.hint_en;
+            $("#hints").append("<div class='alert alert-warning'>" + hint_text + "</div>");
+        });
+    });
+}

--- a/sipa/static/js/agdsn.js
+++ b/sipa/static/js/agdsn.js
@@ -29,7 +29,7 @@ if (window.location.pathname.endsWith("contact")) {
         });
     });
     $("#message").keypress(function () {
-        applicable = hints.filter(function (hint) {
+        var applicable = hints.filter(function (hint) {
             var contains = hint.patterns.some(function (pattern) {
                 return pattern.test($("#message").val())
             });

--- a/sipa/static/js/hints.json
+++ b/sipa/static/js/hints.json
@@ -15,7 +15,7 @@
     }
   },
   {
-    "not_in_dorm": ["hss"],
+    "not_in_dorm": ["hss", "ger"],
     "patterns": [
       "change.{0,10}mac",
       "mac.{0,10}address",
@@ -23,8 +23,8 @@
       "mac.{0,10}adresse"
     ],
     "hint": {
-      "de": "Du kannst deine MAC-Adresse auch selbst ändern wenn du dich einloggst.",
-      "en": "You can change your MAC address yourself if you are logged in."
+      "de": "Du kannst deine MAC-Adresse auch selbst ändern wenn du <a href='login'>dich einloggst.</a>",
+      "en": "You can change your MAC address yourself if you are <a href='login'>logged in.</a>"
     }
   }
 ]

--- a/sipa/static/js/hints.json
+++ b/sipa/static/js/hints.json
@@ -4,6 +4,7 @@
     "patterns": [
       "forgot.{0,10}password",
       "can.?t.{0,10}login",
+      "change.{0,10}password",
       "reset.{0,10}password",
       "passwort.{0,10}vergessen",
       "kann.{0,10}nicht.{0,10}einloggen",

--- a/sipa/static/js/hints.json
+++ b/sipa/static/js/hints.json
@@ -1,0 +1,26 @@
+[
+  {
+    "not_in": [],
+    "patterns": [
+      "forgot.{0,10}password",
+      "can.+t.{0,10}login",
+      "reset.{0,10}password",
+      "passwort.{0,10}vergessen",
+      "kann.{0,10}nicht.{0,10}einloggen",
+      "passwort.{0,10}zurücksetzen"
+    ],
+    "hint_de": "Wir können dein Passwort nicht zurücksetzen ohne dich zu identifizieren. Bitte komme mit einem Lichtbildausweis zu einer unserer <a href='pages/support/contacts'>Sprechstunden</a>",
+    "hint_en": "We can't reset your password without identifying you first. Please come with an id card to one of our <a href='pages/support/contacts'>office hours</a>"
+  },
+  {
+    "not_in": ["hss"],
+    "patterns": [
+      "change.{0,10}mac",
+      "mac.{0,10}address",
+      "mac.{0,10}ändern",
+      "mac.{0,10}adresse"
+    ],
+    "hint_de": "Du kannst deine MAC-Adresse auch selbst ändern wenn du dich einloggst.",
+    "hint_en": "You can change your MAC address yourself if you are logged in."
+  }
+]

--- a/sipa/static/js/hints.json
+++ b/sipa/static/js/hints.json
@@ -1,6 +1,6 @@
 [
   {
-    "not_in": [],
+    "not_in_dorm": [],
     "patterns": [
       "forgot.{0,10}password",
       "can.?t.{0,10}login",
@@ -9,18 +9,22 @@
       "kann.{0,10}nicht.{0,10}einloggen",
       "passwort.{0,10}zurücksetzen"
     ],
-    "hint_de": "Wir können dein Passwort nicht zurücksetzen ohne dich zu identifizieren. Bitte komme mit einem Lichtbildausweis zu einer unserer <a href='pages/support/contacts'>Sprechstunden</a>",
-    "hint_en": "We can't reset your password without identifying you first. Please come with an id card to one of our <a href='pages/support/contacts'>office hours</a>"
+    "hint": {
+      "de":"Wir können dein Passwort nicht zurücksetzen ohne dich zu identifizieren. Bitte komme mit einem Lichtbildausweis zu einer unserer <a href='pages/support/contacts'>Sprechstunden</a>",
+      "en":"We can't reset your password without identifying you first. Please come with an id card to one of our <a href='pages/support/contacts'>office hours</a>"
+    }
   },
   {
-    "not_in": ["hss"],
+    "not_in_dorm": ["hss"],
     "patterns": [
       "change.{0,10}mac",
       "mac.{0,10}address",
       "mac.{0,10}ändern",
       "mac.{0,10}adresse"
     ],
-    "hint_de": "Du kannst deine MAC-Adresse auch selbst ändern wenn du dich einloggst.",
-    "hint_en": "You can change your MAC address yourself if you are logged in."
+    "hint": {
+      "de": "Du kannst deine MAC-Adresse auch selbst ändern wenn du dich einloggst.",
+      "en": "You can change your MAC address yourself if you are logged in."
+    }
   }
 ]

--- a/sipa/static/js/hints.json
+++ b/sipa/static/js/hints.json
@@ -3,7 +3,7 @@
     "not_in": [],
     "patterns": [
       "forgot.{0,10}password",
-      "can.+t.{0,10}login",
+      "can.?t.{0,10}login",
       "reset.{0,10}password",
       "passwort.{0,10}vergessen",
       "kann.{0,10}nicht.{0,10}einloggen",

--- a/sipa/static/js/hints.json
+++ b/sipa/static/js/hints.json
@@ -26,5 +26,18 @@
       "de": "Du kannst deine MAC-Adresse auch selbst ändern wenn du <a href='login'>dich einloggst.</a>",
       "en": "You can change your MAC address yourself if you are <a href='login'>logged in.</a>"
     }
+  },
+  {
+    "not_in_dorm": ["ger"],
+    "patterns": [
+      "balance",
+      "transfer",
+      "überweis",
+      "überwies"
+    ],
+    "hint": {
+      "de": "Wenn du wissen möchtest für wie viele Monate du deinen Mitgliedschaftsbeitrag noch bezahlt hast kannst du das <a href='login'>eingeloggt</a> selbst tun. Beachte aber, dass Banküberweisungen einige Tage dauern können.",
+      "en": "If you want to know your balance you can check it yourself after <a href='login'>logging in</a>. Please be aware that bank transfers can take some days."
+    }
   }
 ]

--- a/sipa/templates/anonymous_contact.html
+++ b/sipa/templates/anonymous_contact.html
@@ -10,8 +10,6 @@
             <strong>{{ _("Hinweis:") }}</strong>
             {{ _("Wenn du uns angemeldet schreibst, können wir Dich als Mitglied "
             "identifizieren und Deine Anfrage schneller bearbeiten!") }}
-            {{ _("Außerdem kannst Du in Deinen Einstellungen bereits einige Daten "
-            "wie z.B. die MAC-Adresse selbstständig ändern.") }}
             <div>
                 <span class="glyphicon glyphicon-share-alt"></span>
                 {% if current_user.is_authenticated -%}

--- a/sipa/templates/anonymous_contact.html
+++ b/sipa/templates/anonymous_contact.html
@@ -4,6 +4,8 @@
 
 {% block content %}
     {% call forms.render(form=form, form_id='anonymous_contact_form', reset_button=False, cancel_to=url_for('generic.index')) %}
+        <div id="hints" class="{{ form_input_offset_class }} {{ form_input_width_class }}">
+        </div>
         <div class="{{ form_input_offset_class }} {{ form_input_width_class }} alert alert-info">
             <strong>{{ _("Hinweis:") }}</strong>
             {{ _("Wenn du uns angemeldet schreibst, können wir Dich als Mitglied "

--- a/sipa/templates/base.html
+++ b/sipa/templates/base.html
@@ -58,10 +58,8 @@ We like where you're looking. Wanna see more? Contact us at du-bist-gefragt<at>a
         <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/style.css') }}"/>
         {% block custom_css %}{% endblock %}
 
-        <script>
-            function get_language() {
-                return "{{ get_locale() }}";
-            }
+        <script type="application/json" id="locale">
+            {{ get_locale() | string | tojson }}
         </script>
     </head>
 

--- a/sipa/templates/base.html
+++ b/sipa/templates/base.html
@@ -57,6 +57,12 @@ We like where you're looking. Wanna see more? Contact us at du-bist-gefragt<at>a
         <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/bootstrap-social.css') }}"/>
         <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/style.css') }}"/>
         {% block custom_css %}{% endblock %}
+
+        <script>
+            function get_language() {
+                return "{{ get_locale() }}";
+            }
+        </script>
     </head>
 
     <body>


### PR DESCRIPTION
Add a script that scans the message typed into the contact form for
common problem descriptions and suggests how the user could resolve the
problem himself instead of messaging us. See the [Demo](http://agdsn.me/~sgeisler/contact_hints.mkv).

At the moment I'm not sure how to test this, since it's purely an UI thing and we don't have any automated UI testing integrated in our pipeline.

TODO:
- [ ] Run the tests and see them pass
- [ ] Rebase your branch on top of `develop`
