### PR TITLE
Assess hints on input instead of on keypress event

### DIFF
--- a/sipa/static/js/agdsn.js
+++ b/sipa/static/js/agdsn.js
@@ -15,7 +15,7 @@ if (window.location.pathname.endsWith("contact")) {
             };
         });
     });
-    $("#message").keypress(function () {
+    $("#message").on("input", function () {
         var applicable = hints.filter(function (hint) {
             var contains = hint.patterns.some(function (pattern) {
                 return pattern.test($("#message").val())


### PR DESCRIPTION
A keypress event handler will not see the changes resulting from its
event. Therefore the hint will only appear after the next keypress.
