### PR TITLE
Run pip as a subprocess

### DIFF
--- a/build/install_requirements.py
+++ b/build/install_requirements.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 import sys
 from os.path import join
-
-import pip
-
+import subprocess
 
 DEFAULT_REQUIREMENTS = 'requirements.txt'
 # this script expect to be started from `sipa/`
@@ -13,7 +11,9 @@ PATH = './build/requirements/'
 def main():
     files_to_install = {DEFAULT_REQUIREMENTS, *sys.argv[1:]}
     for filename in files_to_install:
-        pip.main(['install', '-r', join(PATH, filename)])
+        subprocess.check_call(
+            [sys.executable, '-m', 'pip', 'install', '-r', join(PATH, filename)])
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
The pip documentation [states](https://pip.pypa.io/en/latest/user_guide/#using-pip-from-your-program) that you must not use pip's internal API, but instead should run pip as a subprocess.

With pip 10 the `pip.main` function was moved to `pip._internal.main`, which broke our `install_requirements.py` script.