### PR TITLE
fix iban in girocode

### DIFF
--- a/sipa/blueprints/usersuite.py
+++ b/sipa/blueprints/usersuite.py
@@ -157,7 +157,7 @@ def generate_epc_qr_code(details: PaymentDetails, months):
     return EPC_FORMAT.format(
         bic=details.bic,
         recipient=details.recipient,
-        iban=details.iban,
+        iban=details.iban.replace(' ', ''),
         amount=months * MEMBERSHIP_CONTRIBUTION / 100,
         purpose=details.purpose)
 


### PR DESCRIPTION
The girocode didn't work correctly in all banking-apps because the IBAN contained spaces.
