### PR TITLE
Implement mail deletion feature for WU datasource

### DIFF
--- a/sipa/model/user.py
+++ b/sipa/model/user.py
@@ -3,6 +3,7 @@
 # noinspection PyMethodMayBeStatic
 from abc import ABCMeta, abstractmethod
 from collections import namedtuple
+from contextlib import contextmanager
 
 from sipa.model.fancy_property import active_prop, UnsupportedProperty
 from sipa.model.misc import PaymentDetails
@@ -84,6 +85,25 @@ class BaseUser(AuthenticatedUserMixin, metaclass=ABCMeta):
 
     def re_authenticate(self, password):
         self.authenticate(self.uid, password)
+
+    @contextmanager
+    def tmp_authentication(self, password):
+        """Check and temporarily store the given password.
+
+        Returns a context manager.  The password is stored in
+        `self._tmp_password`.
+
+        This is quite an ugly hack, only existing because some datasources
+        need the user password to change certain user properties such as mail
+        address and MAC address. The need for the password breaks
+        compatability with the usual `instance.property = value`.
+
+        I could not think of a better way to get around this.
+        """
+        self.re_authenticate(password)
+        self._tmp_password = password
+        yield
+        del self._tmp_password
 
     @classmethod
     @abstractmethod

--- a/sipa/model/wu/user.py
+++ b/sipa/model/wu/user.py
@@ -239,10 +239,9 @@ class User(BaseUser):
     def mail(self, new_mail):
         change_email(self.uid, self._tmp_password, new_mail)
 
-    # See https://github.com/agdsn/sipa/issues/234
-    # @mail.deleter
-    # def mail(self):
-    #     self._mail = ''
+    @mail.deleter
+    def mail(self):
+        change_email(self.uid, self._tmp_password, None)
 
     @active_prop
     def address(self):

--- a/sipa/model/wu/user.py
+++ b/sipa/model/wu/user.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import logging
-from contextlib import contextmanager
 from datetime import datetime, timedelta
 from ipaddress import IPv4Address, AddressValueError
 
@@ -206,27 +205,6 @@ class User(BaseUser):
     max_credit = 210 * 1024 * 1024
     daily_credit = 10 * 1024 * 1024
 
-    @contextmanager
-    def tmp_authentication(self, password):
-        """Check and temporarily store the given password.
-
-        Returns a context manager.  The password is stored in
-        `self.__password`.
-
-        This is quite an ugly hack, only existing because sipa does
-        not have an ldap bind for this datasource and needs the user's
-        password.  THe need for the password breaks compatability with
-        the usual `instance.property = value` – now, an AttributeError
-        has to be catched and in that case this wrapper has to be used.
-
-        I could not think of a better way to get around this.
-
-        """
-        self.re_authenticate(password)
-        self.__password = password
-        yield
-        del self.__password
-
     @active_prop
     def login(self):
         return self.uid
@@ -259,7 +237,7 @@ class User(BaseUser):
 
     @mail.setter
     def mail(self, new_mail):
-        change_email(self.uid, self.__password, new_mail)
+        change_email(self.uid, self._tmp_password, new_mail)
 
     # See https://github.com/agdsn/sipa/issues/234
     # @mail.deleter


### PR DESCRIPTION
Maybe spreading the authentication contextmanager hack does not seem like a good idea, but I think its better to use it consequently for all datasources (the upcoming pycroft datasource will also need it) than to make exceptions for a specific datasource.

Fixes #234 and #134
