### PR TITLE
Add a proper Pycroft API schema

### DIFF
--- a/sipa/backends/exceptions.py
+++ b/sipa/backends/exceptions.py
@@ -1,2 +1,8 @@
 class InvalidConfiguration(IndexError):
     pass
+
+
+class BackendError(RuntimeError):
+    def __init__(self, backend_name: str, *a, **kw):
+        self.backend_name = backend_name
+        super().__init__(*a, **kw)

--- a/sipa/initialization.py
+++ b/sipa/initialization.py
@@ -27,6 +27,7 @@ from sipa.utils.graph_utils import (generate_credit_chart,
                                     provide_render_function)
 
 logger = logging.getLogger(__name__)
+logger.addHandler(logging.StreamHandler())  # for before logging is configured
 
 
 def init_app(app, **kwargs):
@@ -110,6 +111,8 @@ def load_config_file(app, config=None):
         else:
             logger.info("Successfully read config file %s",
                         os.environ['SIPA_CONFIG_FILE'])
+    else:
+        logger.info("No SIPA_CONFIG_FILE configured. Moving on.")
 
 
 def init_env_and_config(app):

--- a/sipa/model/pycroft/api.py
+++ b/sipa/model/pycroft/api.py
@@ -13,13 +13,13 @@ logger = logging.getLogger(__name__)
 
 
 class PycroftApi():
-    def __init__(self, endpoint, api_key):
+    def __init__(self, endpoint: str, api_key: str):
         if not endpoint.endswith("/"):
             raise InvalidConfiguration("API endpoint must end with a '/'")
         self._endpoint = endpoint
         self._api_key = api_key
 
-    def get_user(self, username):
+    def get_user(self, username: str) -> Tuple[int, dict]:
         return self.get('user/{}'.format(username))
 
     def get_user_from_ip(self, ip):
@@ -59,7 +59,7 @@ class PycroftApi():
         request_function = partial(requests.post, data=data or {})
         return self._do_api_call(request_function, url)
 
-    def _do_api_call(self, request_function, url):
+    def _do_api_call(self, request_function: Callable, url: str) -> Tuple[int, Any]:
         try:
             response = request_function(
                 self._endpoint + url,

--- a/sipa/model/pycroft/api.py
+++ b/sipa/model/pycroft/api.py
@@ -6,6 +6,7 @@ from typing import Callable, Tuple, Any
 import requests
 from requests import ConnectionError, HTTPError
 
+from sipa.backends.exceptions import InvalidConfiguration
 from .exc import PycroftBackendError
 
 logger = logging.getLogger(__name__)
@@ -13,6 +14,8 @@ logger = logging.getLogger(__name__)
 
 class PycroftApi():
     def __init__(self, endpoint, api_key):
+        if not endpoint.endswith("/"):
+            raise InvalidConfiguration("API endpoint must end with a '/'")
         self._endpoint = endpoint
         self._api_key = api_key
 

--- a/sipa/model/pycroft/exc.py
+++ b/sipa/model/pycroft/exc.py
@@ -1,0 +1,6 @@
+from sipa.backends.exceptions import BackendError
+
+
+class PycroftBackendError(BackendError):
+    def __init__(self, *a, **kw):
+        super().__init__('pycroft', *a, **kw)

--- a/sipa/model/pycroft/schema.py
+++ b/sipa/model/pycroft/schema.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-from typing import Any
+from __future__ import annotations
+from typing import List
 
 from sipa.model.pycroft.unserialize import unserializer
 
@@ -10,16 +11,47 @@ class UserData:
     user_id: str
     login: str
     realname: str
-    # TODO introduce UserStatus when nested unserialization
-    status: Any
+    status: UserStatus
     room: str
     mail: str
-    cache: bool  # TODO test that this works by a `json.loads(json.dumps(foo=True))` test
-    traffic_balance: int  # TODO test what comes out there
-    traffic_history: Any
-    interfaces: Any
+    cache: bool
+    traffic_balance: int
+    traffic_history: List[TrafficHistoryEntry]
+    interfaces: List[Interface]
     finance_balance: str
-    finance_history: Any
-    last_finance_update: str  # TODO what type does parse_date expect?
+    finance_history: List[FinanceHistoryEntry]
+    # TODO implement `cls.Meta.custom_constructors`, use `parse_date` for this
+    last_finance_update: str
 
     # TODO introduce properties once they can be excluded
+
+
+@unserializer
+class UserStatus:
+    member: bool
+    traffic_exceeded: bool
+    network_access: bool
+    account_balanced: bool
+    violation: bool
+
+
+@unserializer
+class Interface:
+    id: int
+    mac: str
+    ips: List[str]
+
+
+@unserializer
+class TrafficHistoryEntry:
+    timestamp: str
+    ingress: int
+    egress: int
+    balance: int
+
+
+@unserializer
+class FinanceHistoryEntry:
+    valid_on: str
+    amount: int
+    description: str

--- a/sipa/model/pycroft/schema.py
+++ b/sipa/model/pycroft/schema.py
@@ -18,7 +18,7 @@ class UserData:
     traffic_balance: int
     traffic_history: List[TrafficHistoryEntry]
     interfaces: List[Interface]
-    finance_balance: str
+    finance_balance: int
     finance_history: List[FinanceHistoryEntry]
     # TODO implement `cls.Meta.custom_constructors`, use `parse_date` for this
     last_finance_update: str

--- a/sipa/model/pycroft/schema.py
+++ b/sipa/model/pycroft/schema.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from typing import Any
+
+from sipa.model.pycroft.unserialize import unserializer
+
+
+@unserializer
+class UserData:
+    id: int
+    user_id: str
+    login: str
+    realname: str
+    # TODO introduce UserStatus when nested unserialization
+    status: Any
+    room: str
+    mail: str
+    cache: bool  # TODO test that this works by a `json.loads(json.dumps(foo=True))` test
+    traffic_balance: int  # TODO test what comes out there
+    traffic_history: Any
+    interfaces: Any
+    finance_balance: str
+    finance_history: Any
+    last_finance_update: str  # TODO what type does parse_date expect?
+
+    # TODO introduce properties once they can be excluded

--- a/sipa/model/pycroft/unserialize.py
+++ b/sipa/model/pycroft/unserialize.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Dict
+
+
+class UnserializationError(Exception):
+    pass
+
+
+class MissingKeysError(KeyError, UnserializationError):
+    pass
+
+
+class ConversionError(TypeError, UnserializationError):
+    pass
+
+
+def canonicalize_key(key: str) -> str:
+    return key[:-1] if key.endswith('_') else key
+
+
+def _maybe_setattr(cls, attrname, attr):
+    if attrname in cls.__dict__:
+        return
+    setattr(cls, attrname, attr)
+
+
+def unserializer(cls: type) -> type:
+    annotations = {canonicalize_key(key): val
+                   for key, val in getattr(cls, '__annotations__', {}).items()}
+    setattr(cls, '__annotations__', annotations)
+
+    # noinspection Mypy
+    @property
+    def _json_keys(self):
+        return self.__annotations__.keys()  # TODO we might exclude some things
+
+    _maybe_setattr(cls, '_json_keys', _json_keys)
+
+    def __init__(self, dict_like: dict):
+        # TODO read `Optional` attributes
+        missing_keys = self._json_keys - set(dict_like.keys())
+        if missing_keys:
+            raise MissingKeysError(f"Missing {len(missing_keys)} keys:"
+                                   f" {', '.join(missing_keys)}")
+        # TODO perhaps warn on superfluous keys
+
+        for attrname in self._json_keys:
+            val = dict_like[attrname]
+            type_ = self.__annotations__[attrname]
+            if type_ != Any:
+                try:
+                    converted = type_(val)
+                except (TypeError, ValueError) as e:
+                    raise ConversionError(f"Failed to convert {val!r}"
+                                          f" to type {type_!r}") from e
+            else:
+                converted = val
+            self.__dict__[attrname] = converted
+
+    _maybe_setattr(cls, '__init__', __init__)
+
+    return cls

--- a/sipa/model/pycroft/unserialize.py
+++ b/sipa/model/pycroft/unserialize.py
@@ -101,7 +101,10 @@ def unserializer(cls: type) -> type:
 
     _maybe_setattr(cls, '_json_keys', _json_keys)
 
-    def __init__(self, dict_like: dict):
+    def __init__(self, dict_like: dict = None):
+        if not dict_like:
+            dict_like = {}
+
         # TODO read `Optional` attributes
         module = sys.modules[type(self).__module__]
         constructor_map = {key: constructor_from_annotation(type_=val,
@@ -110,8 +113,11 @@ def unserializer(cls: type) -> type:
 
         missing_keys = set(constructor_map.keys()) - set(dict_like.keys())
         if missing_keys:
-            raise MissingKeysError(f"Missing {len(missing_keys)} keys:"
-                                   f" {', '.join(missing_keys)}")
+            raise MissingKeysError(
+                f"Missing {len(missing_keys)} keys"
+                f" to construct {type(self).__name__}:"
+                f" {', '.join(missing_keys)}"
+            )
         # TODO perhaps warn on superfluous keys
 
         for attrname, constructor in constructor_map.items():

--- a/sipa/model/pycroft/unserialize.py
+++ b/sipa/model/pycroft/unserialize.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-from typing import Any, Dict
+import inspect
+import sys
+from typing import Callable, Optional, Any, List
 
 
 class UnserializationError(Exception):
@@ -24,7 +26,70 @@ def _maybe_setattr(cls, attrname, attr):
     setattr(cls, attrname, attr)
 
 
+MAXDEPTH = 100
+
+
+def constructor_from_generic(name: str, args: tuple, *a, **kw) -> Optional[Callable]:
+    """
+    :param name:  Something like 'List' (like from `List[int]._name`)
+    :param args: Something like `(int,)` from (`List[int].__args__`)
+    :return: A constructor callable or None
+    """
+    if name == Any._name:
+        def constructor(val):
+            return val
+
+    elif name == List._name:
+        if len(args) == 1:
+            item_constructor = constructor_from_annotation(args[0], *a, **kw)
+
+            def constructor(val):
+                return [item_constructor(i) for i in val]
+        else:
+            raise UnserializationError("Cannot find constructor for List[A, ...]"
+                                       " with more than one argument.")
+    else:
+        raise UnserializationError(f"Generic type '{name}' not supported")
+
+    return constructor
+
+
+def constructor_from_annotation(type_, module, maxdepth=MAXDEPTH) -> Callable:
+    """Use the value of an annotation to return an appropriate constructor"""
+    if maxdepth <= 0:
+        raise UnserializationError(
+            "Maxdepth exceeded when trying to lookup constructors."
+            f" the default is {MAXDEPTH}."
+        )
+
+    # un-stringification by eval'ing in module scope
+    if isinstance(type_, str):
+        try:
+            type_ = eval(type_, module.__dict__, None)
+        except NameError:
+            raise UnserializationError(f"Unable to look up type {type_!r}"
+                                       f" in module {module.__name__!r}")
+
+    constructor: Optional[Callable] = None
+
+    # Case 1: known generic
+    if hasattr(type_, '_name'):
+        # TODO: make everything else required, except if we get Optional[...] here
+        constructor = constructor_from_generic(type_._name, getattr(type_, '__args__', ()),
+                                               module=module, maxdepth=maxdepth-1)
+
+    # cases 2, 3: Is an unserializer or something builtin
+    elif inspect.isclass(type_):
+        constructor = type_
+
+    if not constructor:
+        raise UnserializationError(f"Could not find constructor for type {type_!r}")
+
+    return constructor
+
+
 def unserializer(cls: type) -> type:
+    """A class decorator providing a magic __init__ method"""
     annotations = {canonicalize_key(key): val
                    for key, val in getattr(cls, '__annotations__', {}).items()}
     setattr(cls, '__annotations__', annotations)
@@ -38,23 +103,29 @@ def unserializer(cls: type) -> type:
 
     def __init__(self, dict_like: dict):
         # TODO read `Optional` attributes
-        missing_keys = self._json_keys - set(dict_like.keys())
+        module = sys.modules[type(self).__module__]
+        constructor_map = {key: constructor_from_annotation(type_=val,
+                                                            module=module)
+                           for key, val in self.__annotations__.items()}
+
+        missing_keys = set(constructor_map.keys()) - set(dict_like.keys())
         if missing_keys:
             raise MissingKeysError(f"Missing {len(missing_keys)} keys:"
                                    f" {', '.join(missing_keys)}")
         # TODO perhaps warn on superfluous keys
 
-        for attrname in self._json_keys:
+        for attrname, constructor in constructor_map.items():
             val = dict_like[attrname]
-            type_ = self.__annotations__[attrname]
-            if type_ != Any:
-                try:
-                    converted = type_(val)
-                except (TypeError, ValueError) as e:
-                    raise ConversionError(f"Failed to convert {val!r}"
-                                          f" to type {type_!r}") from e
-            else:
+            if not constructor:
                 converted = val
+            else:
+                try:
+                    converted = constructor(val)
+                except (TypeError, ValueError) as e:
+                    typename = self.__annotations__[attrname]
+                    raise ConversionError(f"Failed to convert {val!r}"
+                                          f" to type {typename!r}") from e
+
             self.__dict__[attrname] = converted
 
     _maybe_setattr(cls, '__init__', __init__)

--- a/sipa/model/pycroft/user.py
+++ b/sipa/model/pycroft/user.py
@@ -100,7 +100,8 @@ class User(BaseUser):
     @active_prop
     @connection_dependent
     def ips(self):
-        return ", ".join(ip for i in self.user_data.interfaces for ip in i.ips)
+        ips = sorted(ip for i in self.user_data.interfaces for ip in i.ips)
+        return ", ".join(ips)
 
     @active_prop
     @connection_dependent

--- a/sipa/model/pycroft/user.py
+++ b/sipa/model/pycroft/user.py
@@ -9,6 +9,7 @@ from sipa.model.misc import PaymentDetails
 from sipa.model.exceptions import UserNotFound, PasswordInvalid, \
     MacAlreadyExists, NetworkAccessAlreadyActive
 from .api import PycroftApi
+from .schema import UserData
 
 from flask_login import AnonymousUserMixin
 from flask.globals import current_app
@@ -22,9 +23,11 @@ api: PycroftApi = LocalProxy(lambda: current_app.extensions['pycroft_api'])
 
 
 class User(BaseUser):
-    def __init__(self, user_data):
-        super().__init__(uid=str(user_data['id']))
-        self.cache_user_data(user_data)
+    user_data: UserData
+
+    def __init__(self, user_data: dict):
+        self.user_data = UserData(user_data)
+        super().__init__(uid=str(self.user_data.id))
 
     @classmethod
     def get(cls, username):
@@ -45,7 +48,7 @@ class User(BaseUser):
         return cls(user_data)
 
     def re_authenticate(self, password):
-        self.authenticate(self._login, password)
+        self.authenticate(self.user_data.login, password)
 
     @classmethod
     def authenticate(cls, username, password):
@@ -56,29 +59,10 @@ class User(BaseUser):
 
         return cls.get(result['id'])
 
-    def cache_user_data(self, user_data):
-        self._id = user_data['id']
-        self._user_id = user_data['user_id']
-        self._login = user_data['login']
-        self._realname = user_data['name']
-        self._status = user_data['status']
-        self._address = user_data['room']
-        self._mail = user_data['mail']
-        self._use_cache = user_data['cache']
-        self._credit = user_data['traffic_balance']
-        self._traffic_history = user_data['traffic_history']
-        self._interfaces = user_data['interfaces']
-        self._finance_information = FinanceInformation(
-            balance=user_data['finance_balance'],
-            transactions=((parse_date(t['valid_on']), t['amount']) for t in
-                          user_data['finance_history']),
-            last_update=parse_date(user_data['last_finance_update'])
-        )
-
     can_change_password = True
 
     def change_password(self, old, new):
-        status, result = api.change_password(self._id, old, new)
+        status, result = api.change_password(self.user_data.id, old, new)
 
         if status != 200:
             raise PasswordInvalid
@@ -91,47 +75,47 @@ class User(BaseUser):
             'output': to_kib(entry['egress']),
             'throughput': to_kib(entry['ingress']) + to_kib(entry['egress']),
             'credit': to_kib(entry['balance']),
-        } for entry in self._traffic_history]
+        } for entry in self.user_data.traffic_history]
 
     @property
     def credit(self):
-        return to_kib(self._credit)
+        return to_kib(self.user_data.traffic_balance)
 
     max_credit = 210 * 1024 * 1024
     daily_credit = 5 * 1024 * 1024
 
     @active_prop
     def realname(self):
-        return self._realname
+        return self.user_data.realname
 
     @active_prop
     def login(self):
-        return self._login
+        return self.user_data.login
 
     @active_prop
     @connection_dependent
     def ips(self):
-        return ", ".join(ip for i in self._interfaces for ip in i['ips'])
+        return ", ".join(ip for i in self.user_data.interfaces for ip in i['ips'])
 
     @active_prop
     @connection_dependent
     def mac(self):
-        return {'value': ", ".join(i['mac'] for i in self._interfaces),
-                'tmp_readonly': len(self._interfaces) != 1}
+        return {'value': ", ".join(i['mac'] for i in self.user_data.interfaces),
+                'tmp_readonly': len(self.user_data.interfaces) != 1}
 
     @active_prop
     @connection_dependent
     def network_access_active(self):
-        return {'value': (gettext("Aktiviert") if len(self._interfaces) > 0
+        return {'value': (gettext("Aktiviert") if len(self.user_data.interfaces) > 0
                           else gettext("Nicht aktiviert")),
-                'tmp_readonly': len(self._interfaces) > 0}
+                'tmp_readonly': len(self.user_data.interfaces) > 0}
 
     @network_access_active.setter
     def network_access_active(self, value):
         pass
 
     def activate_network_access(self, password, mac, birthdate, host_name):
-        status, result = api.activate_network_access(self._id, password, mac,
+        status, result = api.activate_network_access(self.user_data.id, password, mac,
                                                      birthdate, host_name)
 
         if status == 401:
@@ -147,10 +131,10 @@ class User(BaseUser):
 
     def change_mac_address(self, new_mac, host_name):
         # if this has been reached despite `tmp_readonly`, this is a bug.
-        assert len(self._interfaces) == 1
+        assert len(self.user_data.interfaces) == 1
 
-        status, result = api.change_mac(self._id, self._tmp_password,
-                                        self._interfaces[0]['id'], new_mac,
+        status, result = api.change_mac(self.user_data.id, self._tmp_password,
+                                        self.user_data.interfaces[0]['id'], new_mac,
                                         host_name)
 
         if status == 401:
@@ -160,11 +144,11 @@ class User(BaseUser):
 
     @active_prop
     def mail(self):
-        return self._mail
+        return self.user_data.mail
 
     @mail.setter
     def mail(self, new_mail):
-        status, result = api.change_mail(self._id, self._tmp_password, new_mail)
+        status, result = api.change_mail(self.user_data.id, self._tmp_password, new_mail)
 
         if status == 401:
             raise PasswordInvalid
@@ -173,7 +157,7 @@ class User(BaseUser):
 
     @mail.deleter
     def mail(self):
-        status, result = api.change_mail(self._id, self._tmp_password, new_mail=None)
+        status, result = api.change_mail(self.user_data.id, self._tmp_password, new_mail=None)
         if status == 401:
             raise PasswordInvalid
         elif status == 404:
@@ -181,20 +165,20 @@ class User(BaseUser):
 
     @active_prop
     def address(self):
-        return self._address
+        return self.user_data.room
 
     @active_prop
     def status(self):
-        value, style = evaluate_status(self._status)
+        value, style = evaluate_status(self.user_data.status)
         return {'value': value, 'style': style}
 
     @active_prop
     def id(self):
-        return self._user_id
+        return self.user_data.user_id
 
     @active_prop
     def use_cache(self):
-        if self._use_cache:
+        if self.user_data.cache:
             return {'value': gettext("Aktiviert"),
                     'raw_value': True,
                     'style': 'success',
@@ -206,7 +190,7 @@ class User(BaseUser):
 
     @use_cache.setter
     def use_cache(self, new_use_cache):
-        api.change_cache_usage(self._id, new_use_cache)
+        api.change_cache_usage(self.user_data.id, new_use_cache)
 
     @unsupported_prop
     def hostname(self):
@@ -230,7 +214,12 @@ class User(BaseUser):
 
     @property
     def finance_information(self):
-        return self._finance_information
+        return FinanceInformation(
+            balance=self.user_data.finance_balance,
+            transactions=((parse_date(t['valid_on']), t['amount']) for t in
+                          self.user_data.finance_history),
+            last_update=parse_date(self.user_data.last_finance_update)
+        )
 
     def payment_details(self) -> PaymentDetails:
         return PaymentDetails(
@@ -239,9 +228,9 @@ class User(BaseUser):
             iban="DE61 8505 0300 3120 2195 40",
             bic="OSDD DE 81 XXX",
             purpose="{id}, {name}, {address}".format(
-                id=self._user_id,
-                name=self._realname,
-                address=self._address,
+                id=self.user_data.user_id,
+                name=self.user_data.realname,
+                address=self.user_data.room,
             ),
         )
 

--- a/sipa/model/pycroft/user.py
+++ b/sipa/model/pycroft/user.py
@@ -9,7 +9,9 @@ from sipa.model.misc import PaymentDetails
 from sipa.model.exceptions import UserNotFound, PasswordInvalid, \
     MacAlreadyExists, NetworkAccessAlreadyActive
 from .api import PycroftApi
+from .exc import PycroftBackendError
 from .schema import UserData, UserStatus
+from .unserialize import UnserializationError
 
 from flask_login import AnonymousUserMixin
 from flask.globals import current_app
@@ -26,7 +28,10 @@ class User(BaseUser):
     user_data: UserData
 
     def __init__(self, user_data: dict):
-        self.user_data: UserData = UserData(user_data)
+        try:
+            self.user_data: UserData = UserData(user_data)
+        except UnserializationError as e:
+            raise PycroftBackendError("Error when parsing user lookup response") from e
         super().__init__(uid=str(self.user_data.id))
 
     @classmethod

--- a/sipa/utils/graph_utils.py
+++ b/sipa/utils/graph_utils.py
@@ -53,7 +53,8 @@ def generate_traffic_chart(traffic_data, inline=True):
     :return: The graph object
     """
     # choose unit according to maximum of `throughput`
-    divisions = max_divisions(max(day['throughput'] for day in traffic_data))
+    divisions = (max_divisions(max(day['throughput'] for day in traffic_data))
+                 if traffic_data else 0)
 
     traffic_data = [{key: (reduce_by_base(val, divisions=divisions)
                            if key in ['input', 'output', 'throughput']

--- a/tests/test_unserialize.py
+++ b/tests/test_unserialize.py
@@ -69,6 +69,20 @@ class UnserializerTest(TestCase):
         self.assertEqual(f.items, ["one", "two"])
 
 
+class EmptyArgumentsTest(TestCase):
+    @unserializer
+    class Foo:
+        bar: str
+
+    def test_no_argument_throws(self):
+        with self.assertRaises(MissingKeysError):
+            self.Foo()
+
+    def test_argument_none_throws(self):
+        with self.assertRaises(MissingKeysError):
+            self.Foo(None)
+
+
 @unserializer
 class Note:
     id_: int

--- a/tests/test_unserialize.py
+++ b/tests/test_unserialize.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+from typing import Any, List
+from unittest import TestCase
+
+from sipa.model.pycroft.unserialize import unserializer, MissingKeysError, ConversionError
+
+
+class UnserializerTest(TestCase):
+    def test_basic_unserializer(self):
+        @unserializer
+        class Foo:
+            bar: str
+
+        try:
+            f = Foo({'bar': "value"})
+        except TypeError:
+            self.fail("TypeError raised")
+        self.assertEqual(f.bar, "value")
+
+        with self.assertRaises(MissingKeysError):
+            Foo({'baz': "something"})
+
+    def test_slash_stripping(self):
+        @unserializer
+        class Foo:
+            type_: str
+
+        with self.assertRaises(MissingKeysError):
+            Foo({'type_': "value"})
+
+        try:
+            f = Foo({'type': "value"})
+        except TypeError:
+            self.fail("TypeError raised")
+        self.assertEqual(f.type, "value")
+
+    def test_type_conversion(self):
+        @unserializer
+        class Foo:
+            count: int
+
+        with self.assertRaises(ConversionError):
+            Foo({'count': "not_an_int"})
+
+    def test_list_cannot_convert(self):
+        @unserializer
+        class Foo:
+            items: List[str]
+
+        with self.assertRaises(ConversionError):
+            Foo({'items': ["bar", "baz"]})
+
+    def test_complex_unserializer(self):
+        @unserializer
+        class Foo:
+            name: str
+            id_: int
+            items: Any
+
+        f = Foo({'name': "Hans", 'id': "555", 'items': ["one", "two"]})
+        self.assertEqual(f.name, "Hans")
+        self.assertEqual(f.id, 555)
+        self.assertEqual(f.items, ["one", "two"])

--- a/tests/test_unserialize.py
+++ b/tests/test_unserialize.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
 from typing import Any, List
 from unittest import TestCase
 

--- a/tests/test_unserialize.py
+++ b/tests/test_unserialize.py
@@ -69,29 +69,32 @@ class UnserializerTest(TestCase):
         self.assertEqual(f.items, ["one", "two"])
 
 
+@unserializer
+class Note:
+    id_: int
+    name: str
+
+
+@unserializer
+class Bar:  # We need to dofine this at module level so the lookup works
+    description: str
+    notes: List[Note]
+
+
+@unserializer
+class Baz:
+    inner: Bar
+
+
 class NestedUnserializationTest(TestCase):
     def setUp(self):
-        @unserializer
-        class Note:
-            id_: int
-            name: str
-
-        @unserializer
-        class Bar:
-            description: str
-            notes: List[Note]
         self._bar_cls = Bar
-
-        @unserializer
-        class Baz:
-            inner: Bar
-
         try:
             self.baz = Baz({'inner': {'description': "Beschreibung",
                                       'notes': [{'id': 1, 'name': "a"},
                                                 {'id': 2, 'name': "b"}]}})
-        except UnserializationError:
-            self.fail("Unserialization failed")
+        except UnserializationError as e:
+            self.fail(f"Unserialization failed: {e}")
 
     def test(self):
         self.assertIsInstance(self.baz.inner, self._bar_cls)


### PR DESCRIPTION
This utilizes a class decorator to automatically transform type-annotated classes into constructible objects.  This has the advantage of your IDE knowing which attributes to expect and proper validation when trying to parse an API result.

Please give me short notice before merging, as this branch bases upon `origin/mail_spoof`, which is to be merged in #390, so I can rebase.