### PR TITLE
add honeypot for spam protection

### DIFF
--- a/sipa/forms.py
+++ b/sipa/forms.py
@@ -71,6 +71,7 @@ class ReadonlyStringField(StrippedStringField):
         return super().__call__(
             *args, readonly=True, **kwargs)
 
+
 class SpamCheckField(StringField):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -81,11 +82,13 @@ class SpamCheckField(StringField):
         kwargs['autocomplete'] = 'off'
         return super().__call__(*args, **kwargs)
 
+
 class SpamProtectedForm(FlaskForm):
     # Adds a honypot for bots to the form.
     # This field must not be filled out to submit the form.
     # We're using 'website' as the field-name since we won't give bots a hint.
-    website = SpamCheckField(label="", validators=[Length(0,0,"You seem to like honey.")])
+    website = SpamCheckField(label="", validators=[Length(0, 0, "You seem to like honey.")])
+
 
 class ContactForm(SpamProtectedForm):
     email = ReadonlyStringField(

--- a/sipa/forms.py
+++ b/sipa/forms.py
@@ -71,8 +71,23 @@ class ReadonlyStringField(StrippedStringField):
         return super().__call__(
             *args, readonly=True, **kwargs)
 
+class SpamCheckField(StringField):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
-class ContactForm(FlaskForm):
+    def __call__(self, *args, **kwargs):
+        c = kwargs.pop('class', '') or kwargs.pop('class_', '')
+        kwargs['class'] = u'%s %s' % ('honey', c)
+        kwargs['autocomplete'] = 'off'
+        return super().__call__(*args, **kwargs)
+
+class SpamProtectedForm(FlaskForm):
+    # Adds a honypot for bots to the form.
+    # This field must not be filled out to submit the form.
+    # We're using 'website' as the field-name since we won't give bots a hint.
+    website = SpamCheckField(label="", validators=[Length(0,0,"You seem to like honey.")])
+
+class ContactForm(SpamProtectedForm):
     email = ReadonlyStringField(
         label=lazy_gettext("Deine E-Mail-Adresse"),
         validators=[Email(lazy_gettext("E-Mail ist nicht in gültigem "
@@ -92,7 +107,7 @@ class ContactForm(FlaskForm):
     ])
 
 
-class AnonymousContactForm(FlaskForm):
+class AnonymousContactForm(SpamProtectedForm):
     email = StrippedStringField(
         label=lazy_gettext("Deine E-Mail-Adresse"),
         validators=[Email(lazy_gettext("E-Mail ist nicht "
@@ -114,7 +129,7 @@ class AnonymousContactForm(FlaskForm):
     ])
 
 
-class OfficialContactForm(FlaskForm):
+class OfficialContactForm(SpamProtectedForm):
     email = StrippedStringField(
         label=lazy_gettext("E-Mail-Adresse"),
         validators=[Email(lazy_gettext("E-Mail ist nicht "

--- a/sipa/static/css/style.css
+++ b/sipa/static/css/style.css
@@ -156,3 +156,7 @@ img[alt=software_logo] {
 #hints div {
 	margin-bottom: 10px;
 }
+
+.honey {
+	display: none;
+}


### PR DESCRIPTION
This PR adds a new Form, which has a honeypot field called 'website' which must not be filled out to pass the spam protection.
The field is hidden by CSS and autocompletion is disabled.

closes #398