### PR TITLE
Pin MarkupSafe to 1.1.1 to avoid incompatibility

### DIFF
--- a/build/requirements/requirements.txt
+++ b/build/requirements/requirements.txt
@@ -20,3 +20,5 @@ typing-extensions~=3.7.2
 email_validator~=1.1.1
 Werkzeug~=1.0.0
 sentry-sdk[flask]~=0.20.3
+# Pin to avoid incompatibility
+MarkupSafe~=1.1.1


### PR DESCRIPTION
Quickfixes `ImportError: cannot import name 'soft_unicode' from 'markupsafe'`.