### PR TITLE
fixed error api handling

### DIFF
--- a/sipa/model/pycroft/api.py
+++ b/sipa/model/pycroft/api.py
@@ -257,7 +257,7 @@ class PycroftApi:
                          extra={'data': {'endpoint': self._endpoint + url}})
             raise PycroftBackendError("Pycroft API unreachable") from e
 
-        if response.status_code not in [200, 400, 401, 403, 404, 412, 422]:
+        if response.status_code not in [200, *range(400, 500)]:
             try:
                 response.raise_for_status()
             except HTTPError as e:


### PR DESCRIPTION
I found a line in which every error code caught from the Pycroft API is listed. I think we should pass all client errors to the user and only throw an error when there is a server error; otherwise, we will end up adding error handling in Pycroft by returning a `4xx` error, as well as throwing errors in SIPA.

- [ x ] Run the tests and see them pass
- [ x ] Rebase your branch on top of `develop`
- [ ] Include tests for features you introduced / bugs you fixed 

This issue fixes #507
