### PR TITLE
updated contribution QR default

### DIFF
--- a/sipa/forms.py
+++ b/sipa/forms.py
@@ -480,7 +480,7 @@ class HostingForm(FlaskForm):
 
 
 class PaymentForm(FlaskForm):
-    months = IntegerField(lazy_gettext("Monate"), default=1,
+    months = IntegerField(lazy_gettext("Monate"), default=6,
                           validators=[NumberRange(min=1, message=lazy_gettext(
                               "Muss mindestens 1 Monat sein."))])
 


### PR DESCRIPTION
updated the amount of membership contribution to default 6 months
In order to avoid additional banking fees, it should be made as easy and understandable as possible for users to pay in advance for a semester, rather than paying every month. 
Therefore I set the default of months which are selected to 6.


- [x] Run the tests and see them pass
- [x] Rebase your branch on top of `develop`

